### PR TITLE
fix: bump actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/sync-google-scholar.yml
+++ b/.github/workflows/sync-google-scholar.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
actions/checkout@v3 -> v4, actions/setup-python@v4 -> v5

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw