### PR TITLE
fix: force Node.js 24 for GitHub Actions runner

### DIFF
--- a/.github/workflows/sync-google-scholar.yml
+++ b/.github/workflows/sync-google-scholar.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw