### PR TITLE
Enhance website: news section, nav tabs, Google Scholar sync

### DIFF
--- a/.github/workflows/sync-google-scholar.yml
+++ b/.github/workflows/sync-google-scholar.yml
@@ -42,7 +42,15 @@ jobs:
       - name: Clear stale publication folders
         if: steps.fetch.outcome == 'success' && steps.diff.outputs.changed == 'true'
         run: |
-          find content/publication -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} +
+          # Delete auto-generated publication folders, but skip any folder that
+          # contains a .keep file — those are manually managed entries.
+          find content/publication -mindepth 1 -maxdepth 1 -type d | while read -r dir; do
+            if [ ! -f "$dir/.keep" ]; then
+              rm -rf "$dir"
+            else
+              echo "Skipping manually managed entry: $dir"
+            fi
+          done
 
       - name: Convert BibTeX to Hugo Markdown
         if: steps.fetch.outcome == 'success' && steps.diff.outputs.changed == 'true'

--- a/.github/workflows/sync-google-scholar.yml
+++ b/.github/workflows/sync-google-scholar.yml
@@ -39,6 +39,11 @@ jobs:
         run: |
           git diff --quiet publications.bib && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
 
+      - name: Clear stale publication folders
+        if: steps.fetch.outcome == 'success' && steps.diff.outputs.changed == 'true'
+        run: |
+          find content/publication -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} +
+
       - name: Convert BibTeX to Hugo Markdown
         if: steps.fetch.outcome == 'success' && steps.diff.outputs.changed == 'true'
         run: academic import publications.bib content/publication/ --compact

--- a/content/publication/_manual-template/index.md
+++ b/content/publication/_manual-template/index.md
@@ -1,0 +1,37 @@
+---
+title: 'Paper Title Here'
+authors:
+  - Alice Qian
+  - Co-Author Name
+date: '2025-01-01'
+publishDate: '2025-01-01'
+
+# Publication type:
+# 0 = Uncategorized, 1 = Conference paper, 2 = Journal article,
+# 3 = Preprint, 4 = Report, 5 = Book, 6 = Book section, 7 = Thesis
+publication_types: ['1']
+
+publication: 'Conference or Journal Name'
+publication_short: 'SHORT'
+
+abstract: >
+  Your abstract here.
+
+# Is this a featured publication? (shows at top)
+featured: false
+
+# Links (all optional)
+url_pdf: ''
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+
+# Optional: link to a paper on a preprint server
+# links:
+#   - name: arXiv
+#     url: https://arxiv.org/abs/XXXX.XXXXX
+---


### PR DESCRIPTION
## Summary

- **Recent News section** on the homepage (markdown block with `#news` anchor, easy to edit as bullet points)
- **Projects tab** added to navigation, linking to `/projects/`; removed placeholder pandas/pytorch/scikit example entries
- **Outside Research tab** added to navigation with a new `/outside/` landing page for hobbies, mentorship, personal interests, etc.
- **Google Scholar sync** via GitHub Actions — scrapes your public Scholar profile (`user=9EeaJAkAAAAJ`) monthly using only stdlib Python (no pip dependencies), writes `publications.bib`, then converts to Hugo markdown via `academic import`
- **Manual publication support** — any folder under `content/publication/` containing a `.keep` file is skipped during the auto-cleanup step; a `_manual-template/` folder is included as a copy-paste starting point for pre-publication or manually curated entries
- **Node.js 24 fixes** across all workflows (`checkout@v4`, `setup-python@v5`, `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`)

## Adding a manual paper

1. Copy `content/publication/_manual-template/` to a new folder
2. Fill in `index.md`
3. Leave the `.keep` file in place — the sync will never delete that folder

## Test plan

- [ ] Trigger "Sync Publications from Google Scholar" workflow manually from the Actions tab and verify it fetches only your papers
- [ ] Confirm the new nav tabs (News, Projects, Outside Research) appear and link correctly
- [ ] Add a test manual publication folder with a `.keep` file, trigger the sync, and verify it survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_