### PR TITLE
Fix missing publications and hide template entry

### DIFF
--- a/content/publication/_manual-template/index.md
+++ b/content/publication/_manual-template/index.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: 'Paper Title Here'
 authors:
   - Alice Qian

--- a/content/publication/qian-2025-effective/index.md
+++ b/content/publication/qian-2025-effective/index.md
@@ -1,0 +1,15 @@
+---
+title: 'Effective Automation to Support the Human Infrastructure in AI Red Teaming'
+authors:
+- Alice Qian
+- Jina Suh
+- Mary L Gray
+- Hong Shen
+date: '2025-01-01'
+publication_types:
+- article-journal
+publication: '*Interactions*'
+publication_short: '*Interactions*'
+abstract: ''
+featured: false
+---

--- a/content/publication/qian-2025-locating/index.md
+++ b/content/publication/qian-2025-locating/index.md
@@ -9,5 +9,6 @@ authors:
 date: '2025-09-11'
 publication_types:
 - manuscript
+publication: '*arXiv preprint arXiv:2505.24246*'
 url_pdf: https://arxiv.org/abs/2505.24246
 ---

--- a/content/publication/qian-2025-worker-discretion/index.md
+++ b/content/publication/qian-2025-worker-discretion/index.md
@@ -10,5 +10,6 @@ authors:
 date: '2025-09-11'
 publication_types:
 - article-journal
+publication: '*arXiv preprint arXiv:2509.12140*'
 url_pdf: https://arxiv.org/pdf/2509.12140
 ---


### PR DESCRIPTION
## Summary

Three issues found by scan that were causing publications to not appear on the site:

- **`qian-2025-locating`** — missing `publication` field; added `*arXiv preprint arXiv:2505.24246*`
- **`qian-2025-worker-discretion`** — missing `publication` field; added `*arXiv preprint arXiv:2509.12140*`
- **`qian-2025-effective`** — "Effective Automation to Support the Human Infrastructure in AI Red Teaming" (*Interactions*, vol 32, no 4) existed in `publications.bib` but had no content folder; created `index.md`
- **`_manual-template`** — added `draft: true` so it never renders as a live publication until you copy it and fill it in

## Test plan

- [ ] Confirm all 10 publications appear in the citations list on the homepage
- [ ] Confirm the template entry does not appear on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_