### PR TITLE
fix: restructure homepage to [Bio] / [News | Education + Interests]

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,3 +1,103 @@
+/* ── Homepage bio info row ──────────────────────────────────────────────── */
+
+.bio-info-row {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 3rem;
+  max-width: 960px;
+}
+
+.bio-section-heading {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  opacity: 0.45;
+  margin: 0 0 0.85rem;
+}
+
+/* News column */
+.bio-news-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.bio-news-list li {
+  font-size: 0.9rem;
+  line-height: 1.55;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.12);
+}
+
+.bio-news-list li:last-child {
+  border-bottom: none;
+}
+
+/* Right column: education + interests stacked */
+.bio-col-right {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.bio-right-section {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Education list */
+.bio-education-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.bio-education-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.bio-edu-degree {
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.bio-edu-institution {
+  font-size: 0.85rem;
+  opacity: 0.65;
+}
+
+.bio-edu-years {
+  font-size: 0.78rem;
+  opacity: 0.4;
+}
+
+/* Interests list */
+.bio-interests-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.bio-interests-list li {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  padding: 0.2rem 0;
+}
+
+@media (max-width: 640px) {
+  .bio-info-row {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+}
+
 /* ── Meanwhile page ─────────────────────────────────────────────────────── */
 
 .meanwhile-page {

--- a/content/_index.md
+++ b/content/_index.md
@@ -66,14 +66,31 @@ sections:
               <li><strong>May 2024</strong> — Graduated with B.S. Computer Science from University of Minnesota</li>
             </ul>
           </div>
-          <div class="bio-col bio-col-interests">
-            <h3 class="bio-section-heading">Interests</h3>
-            <ul class="bio-interests-list">
-              <li>human infrastructure for AI 👩🏻</li>
-              <li>AI evaluation ✅</li>
-              <li>future of work 👩🏻‍💻</li>
-              <li>social computing 🌐</li>
-            </ul>
+          <div class="bio-col bio-col-right">
+            <div class="bio-right-section">
+              <h3 class="bio-section-heading">Education</h3>
+              <ul class="bio-education-list">
+                <li>
+                  <span class="bio-edu-degree">Ph.D. Computer Science</span>
+                  <span class="bio-edu-institution">Carnegie Mellon University</span>
+                  <span class="bio-edu-years">2024 – present</span>
+                </li>
+                <li>
+                  <span class="bio-edu-degree">B.S. Computer Science</span>
+                  <span class="bio-edu-institution">University of Minnesota</span>
+                  <span class="bio-edu-years">2020 – 2024</span>
+                </li>
+              </ul>
+            </div>
+            <div class="bio-right-section">
+              <h3 class="bio-section-heading">Interests</h3>
+              <ul class="bio-interests-list">
+                <li>human infrastructure for AI 👩🏻</li>
+                <li>AI evaluation ✅</li>
+                <li>future of work 👩🏻‍💻</li>
+                <li>social computing 🌐</li>
+              </ul>
+            </div>
           </div>
         </div>
     design:

--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -46,28 +46,27 @@ profiles:
   - icon: academicons/orcid
     url: https://orcid.org/0009-0005-6407-6981
 
-# interests moved to the custom news+interests block in content/_index.md
+# interests and education moved to the custom block in content/_index.md
 # interests:
 #   - human infrastructure for AI 👩🏻
 #   - AI evaluation ✅
 #   - future of work 👩🏻‍💻
 #   - social computing 🌐
 
-education:
-  - area: Ph.D. Computer Science
-    institution: Carnegie Mellon University
-    date_start: 2024-09-01
-    # date_end: 2020-12-31
-    summary: |
-      Focus on building tools and methods to support the human infrastructure behind AI development and evaluation. Advised by [Dr. Hong Shen](https://www.andrew.cmu.edu/user/hongs/) and [Dr. Laura Dabbish](http://www.lauradabbish.com/).
-    button:
-      text: 'Carnegie Mellon Website'
-      url: 'https://hcii.cmu.edu/people/alice-qian-zhang'
-  - area: Bachelor of Science Computer Science
-    institution: University of Minnesota
-    date_start: 2020-09-01
-    date_end: 2024-05-30
-    # summary: 
+# education:
+#   - area: Ph.D. Computer Science
+#     institution: Carnegie Mellon University
+#     date_start: 2024-09-01
+#     summary: |
+#       Focus on building tools and methods to support the human infrastructure behind AI development and evaluation. Advised by [Dr. Hong Shen](https://www.andrew.cmu.edu/user/hongs/) and [Dr. Laura Dabbish](http://www.lauradabbish.com/).
+#     button:
+#       text: 'Carnegie Mellon Website'
+#       url: 'https://hcii.cmu.edu/people/alice-qian-zhang'
+#   - area: Bachelor of Science Computer Science
+#     institution: University of Minnesota
+#     date_start: 2020-09-01
+#     date_end: 2024-05-30
+#     # summary:
       
 # work:
 #   - position: Director of Cloud Infrastructure


### PR DESCRIPTION
Move education out of the resume-biography-3 block into the custom two-column section, placing it alongside interests on the right. News stays on the left. Also restores missing bio layout CSS that was lost in a prior merge.


Claude-Session: https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw