### PR TITLE
feat: condensed homepage layout, publications by year, clean paper pages

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,3 +1,10 @@
+/* ── Break Hugo Blox prose width limits for bio blocks ──────────────────── */
+
+#bio .prose,
+#info .prose {
+  max-width: none;
+}
+
 /* ── Homepage hero (photo + bio) ────────────────────────────────────────── */
 
 .homepage-hero {
@@ -5,7 +12,7 @@
   grid-template-columns: 200px 1fr;
   gap: 3rem;
   align-items: start;
-  max-width: 960px;
+  width: 100%;
 }
 
 .hero-avatar {
@@ -106,7 +113,7 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 3rem;
-  max-width: 960px;
+  width: 100%;
 }
 
 .bio-section-heading {

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -344,6 +344,97 @@
   .pub-thumb { width: 80px; height: 56px; }
 }
 
+/* ── Publication single page ─────────────────────────────────────────────── */
+
+.pub-single {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 5rem;
+}
+
+.pub-single-header {
+  margin-bottom: 2rem;
+}
+
+.pub-single-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.pub-single-date {
+  font-size: 0.82rem;
+  opacity: 0.45;
+}
+
+.pub-single-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1.3;
+  margin: 0 0 0.75rem;
+}
+
+.pub-single-authors {
+  font-size: 0.88rem;
+  opacity: 0.6;
+  margin: 0 0 0.25rem;
+}
+
+.pub-single-venue {
+  font-size: 0.82rem;
+  opacity: 0.45;
+  font-style: italic;
+  margin: 0 0 1.25rem;
+}
+
+.pub-single-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 1.25rem;
+}
+
+.pub-single-image {
+  margin: 2rem 0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.pub-single-image img {
+  width: 100%;
+  display: block;
+}
+
+.pub-single-abstract {
+  margin: 2rem 0;
+}
+
+.pub-single-section-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.4;
+  margin: 0 0 0.75rem;
+}
+
+.pub-single-back {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(128,128,128,0.15);
+}
+
+.pub-single-back a {
+  font-size: 0.85rem;
+  opacity: 0.5;
+  text-decoration: none;
+}
+
+.pub-single-back a:hover {
+  opacity: 1;
+}
+
 /* ── Meanwhile page ─────────────────────────────────────────────────────── */
 
 .meanwhile-page {

--- a/layouts/publication/list.html
+++ b/layouts/publication/list.html
@@ -3,62 +3,38 @@
 
   <h1 class="pub-list-title">Publications</h1>
 
-  {{/* Group publications by year, descending */}}
+  {{/* Group publications by year descending using Hugo's built-in GroupByDate */}}
   {{ $pubs := where site.RegularPages "Section" "publication" }}
   {{ $pubs = where $pubs "Params.draft" "ne" true }}
-  {{ $byYear := dict }}
-  {{ range $pubs }}
-    {{ $year := .Date.Format "2006" }}
-    {{ $existing := index $byYear $year | default slice }}
-    {{ $byYear = merge $byYear (dict $year (append $existing .)) }}
-  {{ end }}
 
-  {{ $years := slice }}
-  {{ range $year, $_ := $byYear }}
-    {{ $years = append $years $year }}
-  {{ end }}
-  {{ $years = sort $years "value" "desc" }}
-
-  {{ range $years }}
-  {{ $year := . }}
-  {{ $yearPubs := index $byYear $year }}
+  {{ range ($pubs.GroupByDate "2006").Reverse }}
   <div class="pub-year-group">
-    <h2 class="pub-year-label">{{ $year }}</h2>
+    <h2 class="pub-year-label">{{ .Key }}</h2>
     <div class="pub-year-list">
-      {{ range sort $yearPubs "Date" "desc" }}
-      {{ $pub := . }}
+      {{ range .Pages }}
 
-      {{/* Determine type badge label */}}
+      {{/* Determine type badge */}}
       {{ $typeLabel := "" }}
       {{ $typeClass := "" }}
       {{ with .Params.publication_types }}
         {{ $t := index . 0 }}
         {{ if eq $t "article-journal" }}
-          {{ $typeLabel = "Journal" }}
-          {{ $typeClass = "badge-journal" }}
+          {{ $typeLabel = "Journal" }}{{ $typeClass = "badge-journal" }}
         {{ else if eq $t "paper-conference" }}
-          {{ $typeLabel = "Conference" }}
-          {{ $typeClass = "badge-conference" }}
+          {{ $typeLabel = "Conference" }}{{ $typeClass = "badge-conference" }}
         {{ else if eq $t "chapter" }}
-          {{ $typeLabel = "Workshop" }}
-          {{ $typeClass = "badge-workshop" }}
+          {{ $typeLabel = "Workshop" }}{{ $typeClass = "badge-workshop" }}
         {{ else if eq $t "manuscript" }}
-          {{ $typeLabel = "Preprint" }}
-          {{ $typeClass = "badge-preprint" }}
+          {{ $typeLabel = "Preprint" }}{{ $typeClass = "badge-preprint" }}
         {{ else }}
-          {{ $typeLabel = $t }}
-          {{ $typeClass = "badge-other" }}
+          {{ $typeLabel = $t }}{{ $typeClass = "badge-other" }}
         {{ end }}
       {{ end }}
 
-      {{/* Thumbnail: page resource image or featured_image */}}
+      {{/* Thumbnail: page resource named featured.* */}}
       {{ $thumb := "" }}
       {{ with .Resources.GetMatch "featured*" }}
         {{ $thumb = .RelPermalink }}
-      {{ else }}
-        {{ with .Params.image }}
-          {{ $thumb = .filename | printf "/media/%s" }}
-        {{ end }}
       {{ end }}
 
       <article class="pub-entry{{ if $thumb }} has-thumb{{ end }}">
@@ -80,22 +56,16 @@
             <a href="{{ .RelPermalink }}">{{ .Title }}</a>
           </h3>
           <p class="pub-authors">
-            {{ with .Params.authors }}
-              {{ delimit . ", " }}
-            {{ end }}
+            {{ with .Params.authors }}{{ delimit . ", " }}{{ end }}
           </p>
           <div class="pub-actions">
-            {{ with .Params.url_pdf }}
-            {{ if . }}
+            {{ with .Params.url_pdf }}{{ if . }}
             <a href="{{ . }}" class="pub-btn pub-btn-pdf" target="_blank" rel="noopener">PDF</a>
-            {{ end }}
-            {{ end }}
-            {{ with .Params.url_video }}
-            {{ if . }}
+            {{ end }}{{ end }}
+            {{ with .Params.url_video }}{{ if . }}
             <a href="{{ . }}" class="pub-btn pub-btn-video" target="_blank" rel="noopener">Video</a>
-            {{ end }}
-            {{ end }}
-            <a href="{{ $pub.RelPermalink }}" class="pub-btn pub-btn-cite">Details</a>
+            {{ end }}{{ end }}
+            <a href="{{ .RelPermalink }}" class="pub-btn pub-btn-cite">Details</a>
           </div>
         </div>
       </article>

--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -1,0 +1,73 @@
+{{ define "main" }}
+<article class="pub-single">
+
+  <div class="pub-single-header">
+    {{/* Type badge */}}
+    {{ $typeLabel := "" }}
+    {{ $typeClass := "" }}
+    {{ with .Params.publication_types }}
+      {{ $t := index . 0 }}
+      {{ if eq $t "article-journal" }}
+        {{ $typeLabel = "Journal" }}{{ $typeClass = "badge-journal" }}
+      {{ else if eq $t "paper-conference" }}
+        {{ $typeLabel = "Conference" }}{{ $typeClass = "badge-conference" }}
+      {{ else if eq $t "chapter" }}
+        {{ $typeLabel = "Workshop" }}{{ $typeClass = "badge-workshop" }}
+      {{ else if eq $t "manuscript" }}
+        {{ $typeLabel = "Preprint" }}{{ $typeClass = "badge-preprint" }}
+      {{ else }}
+        {{ $typeLabel = $t }}{{ $typeClass = "badge-other" }}
+      {{ end }}
+    {{ end }}
+
+    <div class="pub-single-meta">
+      {{ if $typeLabel }}
+      <span class="pub-badge {{ $typeClass }}">{{ $typeLabel }}</span>
+      {{ end }}
+      <span class="pub-single-date">{{ .Date.Format "2006" }}</span>
+    </div>
+
+    <h1 class="pub-single-title">{{ .Title }}</h1>
+
+    {{ with .Params.authors }}
+    <p class="pub-single-authors">{{ delimit . " · " }}</p>
+    {{ end }}
+
+    {{ with .Params.publication }}
+    <p class="pub-single-venue">{{ . | markdownify }}</p>
+    {{ end }}
+
+    <div class="pub-single-actions">
+      {{ with .Params.url_pdf }}{{ if . }}
+      <a href="{{ . }}" class="pub-btn pub-btn-pdf" target="_blank" rel="noopener">PDF</a>
+      {{ end }}{{ end }}
+      {{ with .Params.url_video }}{{ if . }}
+      <a href="{{ . }}" class="pub-btn pub-btn-video" target="_blank" rel="noopener">Video</a>
+      {{ end }}{{ end }}
+      {{ with .Params.url_source }}{{ if . }}
+      <a href="{{ . }}" class="pub-btn" target="_blank" rel="noopener">Source</a>
+      {{ end }}{{ end }}
+    </div>
+  </div>
+
+  {{/* Featured image */}}
+  {{ with .Resources.GetMatch "featured*" }}
+  <div class="pub-single-image">
+    <img src="{{ .RelPermalink }}" alt="{{ $.Title }}" loading="lazy">
+  </div>
+  {{ end }}
+
+  {{/* Abstract / body */}}
+  {{ if .Content }}
+  <div class="pub-single-abstract">
+    <h2 class="pub-single-section-label">Abstract</h2>
+    {{ .Content }}
+  </div>
+  {{ end }}
+
+  <div class="pub-single-back">
+    <a href="/publication/">← All Publications</a>
+  </div>
+
+</article>
+{{ end }}


### PR DESCRIPTION
## Summary

- **Homepage whitespace fix**: overrides Hugo Blox's `.prose` max-width constraint so the bio/info sections use full available width instead of being cramped on the right
- **Publications ordered by most recent year**: `/publication/` list groups papers by year descending (newest year first) via `GroupByDate "2006" .Reverse`
- **Clean individual paper pages**: custom `layouts/publication/single.html` replaces the Hugo Blox default — shows title, type badge, year, authors, venue, PDF/Video/Source buttons, featured image, and abstract with no social media sharing buttons

## Test plan

- [ ] Homepage: right column (bio text) should fill its grid cell without excess whitespace
- [ ] `/publication/`: papers grouped by year, newest year at top
- [ ] Individual paper page (e.g. `/publication/some-paper/`): no Twitter/Facebook/LinkedIn share buttons, clean layout with action buttons and abstract

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_