### PR TITLE
fix: publication types, venues, and remove News from nav

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -7,9 +7,6 @@ main:
   - name: Bio
     url: /#bio
     weight: 10
-  - name: News
-    url: /#news
-    weight: 11
   - name: Publications
     url: /publication/
     weight: 12

--- a/content/publication/cazacu-2026-actualizing/index.md
+++ b/content/publication/cazacu-2026-actualizing/index.md
@@ -12,7 +12,7 @@ authors:
 date: '2026-01-01'
 publishDate: '2026-01-01'
 publication_types:
-- article-journal
-publication: '*ACM FAccT CRAFT 21*'
+- chapter
+publication: '*ACM FAccT CRAFT 2026*'
 featured: false
 ---

--- a/content/publication/choong-2026-towards/index.md
+++ b/content/publication/choong-2026-towards/index.md
@@ -12,7 +12,7 @@ authors:
 date: '2026-01-01'
 publishDate: '2026-01-01'
 publication_types:
-- article-journal
+- manuscript
 publication: '*arXiv preprint arXiv:2605.07986*'
 featured: false
 ---

--- a/content/publication/han-2025-poet/index.md
+++ b/content/publication/han-2025-poet/index.md
@@ -11,6 +11,6 @@ date: '2025-01-01'
 publishDate: '2025-01-01'
 publication_types:
 - paper-conference
-publication: '*Proceedings of the 38th Annual ACM Symposium on User Interface Software and …*'
+publication: '*UIST 2025*'
 featured: false
 ---

--- a/content/publication/peng-2025-exploring/index.md
+++ b/content/publication/peng-2025-exploring/index.md
@@ -13,7 +13,7 @@ authors:
 date: '2025-01-01'
 publishDate: '2025-01-01'
 publication_types:
-- article-journal
+- manuscript
 publication: '*arXiv preprint arXiv:2509.24167*'
 featured: false
 ---

--- a/content/publication/qian-2023-cleaning/index.md
+++ b/content/publication/qian-2023-cleaning/index.md
@@ -7,7 +7,7 @@ authors:
 date: '2023-01-01'
 publishDate: '2023-01-01'
 publication_types:
-- article-journal
+- manuscript
 publication: '*arXiv preprint arXiv:2309.06688*'
 featured: false
 url_pdf: https://arxiv.org/abs/2309.06688

--- a/content/publication/qian-2023-pragmatic/index.md
+++ b/content/publication/qian-2023-pragmatic/index.md
@@ -7,8 +7,8 @@ authors:
 date: '2023-01-01'
 publishDate: '2023-01-01'
 publication_types:
-- article-journal
-publication: '*Companion Publication of the*'
+- chapter
+publication: ''
 featured: false
 url_pdf: https://dl.acm.org/doi/abs/10.1145/3584931.3607013
 url_video: ''

--- a/content/publication/qian-2024-the/index.md
+++ b/content/publication/qian-2024-the/index.md
@@ -12,7 +12,7 @@ authors:
 date: '2024-01-01'
 publishDate: '2024-01-01'
 publication_types:
-- article-journal
-publication: '*Companion Publication of the*'
+- chapter
+publication: ''
 featured: false
 ---

--- a/content/publication/qian-2025-the/index.md
+++ b/content/publication/qian-2025-the/index.md
@@ -11,7 +11,7 @@ authors:
 date: '2025-01-01'
 publishDate: '2025-01-01'
 publication_types:
-- article-journal
-publication: '*Companion Publication of the*'
+- chapter
+publication: ''
 featured: false
 ---

--- a/content/publication/qian-2026-human/index.md
+++ b/content/publication/qian-2026-human/index.md
@@ -11,7 +11,7 @@ authors:
 date: '2026-01-01'
 publishDate: '2026-01-01'
 publication_types:
-- paper-conference
-publication: '*Proceedings of the Extended Abstracts of the*'
+- chapter
+publication: ''
 featured: false
 ---

--- a/content/publication/qian-2026-worker/index.md
+++ b/content/publication/qian-2026-worker/index.md
@@ -11,6 +11,6 @@ date: '2026-01-01'
 publishDate: '2026-01-01'
 publication_types:
 - paper-conference
-publication: '*Proceedings of the*'
+publication: ''
 featured: false
 ---

--- a/content/publication/tang-2026-beyond/index.md
+++ b/content/publication/tang-2026-beyond/index.md
@@ -12,7 +12,7 @@ authors:
 date: '2026-01-01'
 publishDate: '2026-01-01'
 publication_types:
-- article-journal
+- manuscript
 publication: '*arXiv preprint arXiv:2602.01694*'
 featured: false
 ---

--- a/content/publication/xiao-2025-constructing/index.md
+++ b/content/publication/xiao-2025-constructing/index.md
@@ -13,7 +13,7 @@ authors:
 date: '2025-01-01'
 publishDate: '2025-01-01'
 publication_types:
-- article-journal
+- manuscript
 publication: '*arXiv preprint arXiv:2505.20623*'
 featured: false
 ---

--- a/content/publication/xiao-2025-what/index.md
+++ b/content/publication/xiao-2025-what/index.md
@@ -11,7 +11,7 @@ authors:
 date: '2025-01-01'
 publishDate: '2025-01-01'
 publication_types:
-- article-journal
+- manuscript
 publication: '*arXiv preprint arXiv:2506.05687*'
 featured: false
 ---


### PR DESCRIPTION
- Remove News link from top nav bar
- Tag all "Companion Publication" papers as Workshop (chapter type)
- Tag "Extended Abstracts" paper as Workshop
- Clear truncated/incomplete venue strings ("Companion Publication of the", "Proceedings of the", "Extended Abstracts of the")
- Fix UIST paper venue to "UIST 2025"
- Fix FAccT CRAFT paper type to Workshop
- Change all 6 arXiv preprint papers to manuscript type (Preprint badge)


Claude-Session: https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw