### PR TITLE
feat: two-section projects page (Current Work + Research Themes)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -712,3 +712,222 @@ a.meanwhile-cell:hover .cell-arrow {
   .meanwhile-grid { grid-template-columns: 1fr; }
   .meanwhile-cell { grid-column: span 1 !important; grid-row: span 1 !important; }
 }
+
+/* ── Projects page ───────────────────────────────────────────────────────── */
+
+.projects-page {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 5rem;
+}
+
+.projects-header {
+  margin-bottom: 3.5rem;
+}
+
+.projects-title {
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.5rem;
+}
+
+.projects-subtitle {
+  font-size: 1rem;
+  opacity: 0.55;
+  margin: 0;
+  max-width: 560px;
+}
+
+.projects-section {
+  margin-bottom: 4rem;
+}
+
+.projects-section-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.4;
+  margin: 0 0 0.35rem;
+}
+
+.projects-section-desc {
+  font-size: 0.85rem;
+  opacity: 0.45;
+  margin: 0 0 1.75rem;
+}
+
+/* ── Active project cards ─────────────────────────────────────────────── */
+
+.projects-active-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.25rem;
+}
+
+.project-active-card {
+  position: relative;
+  border: 1px solid rgba(128,128,128,0.15);
+  border-radius: 10px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.project-card-image img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  display: block;
+}
+
+.project-card-body {
+  padding: 1.25rem 1.25rem 1.5rem;
+  flex: 1;
+}
+
+.project-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
+}
+
+.project-tag {
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  padding: 0.2rem 0.55rem;
+  border-radius: 20px;
+  border: 1px solid rgba(128,128,128,0.25);
+  opacity: 0.65;
+}
+
+.project-card-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  line-height: 1.3;
+}
+
+.project-card-summary {
+  font-size: 0.85rem;
+  line-height: 1.6;
+  opacity: 0.6;
+  margin: 0;
+}
+
+.project-status-badge {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.55rem;
+  border-radius: 20px;
+  background: rgba(34, 197, 94, 0.15);
+  color: rgb(34, 197, 94);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+}
+
+/* ── Research theme entries ───────────────────────────────────────────── */
+
+.projects-themes-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.project-theme {
+  padding: 2rem 0;
+  border-bottom: 1px solid rgba(128,128,128,0.12);
+}
+
+.project-theme:first-child {
+  padding-top: 0;
+}
+
+.project-theme-header {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  margin-bottom: 1.25rem;
+}
+
+.project-theme-image {
+  flex-shrink: 0;
+  width: 120px;
+}
+
+.project-theme-image img {
+  width: 120px;
+  height: 90px;
+  object-fit: cover;
+  border-radius: 6px;
+  display: block;
+}
+
+.project-theme-meta {
+  flex: 1;
+}
+
+.project-theme-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0.4rem 0 0.5rem;
+  line-height: 1.3;
+}
+
+.project-theme-summary {
+  font-size: 0.87rem;
+  line-height: 1.65;
+  opacity: 0.6;
+  margin: 0;
+}
+
+.project-theme-pubs {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-left: 0;
+}
+
+.project-pub-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.6rem 0.85rem;
+  border-radius: 6px;
+  background: rgba(128,128,128,0.05);
+  border: 1px solid rgba(128,128,128,0.1);
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.project-pub-link:hover {
+  background: rgba(128,128,128,0.1);
+}
+
+.project-pub-title {
+  font-size: 0.85rem;
+  line-height: 1.4;
+  flex: 1;
+}
+
+.project-pub-meta {
+  font-size: 0.75rem;
+  opacity: 0.4;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+@media (max-width: 600px) {
+  .projects-active-grid { grid-template-columns: 1fr; }
+  .project-theme-image { display: none; }
+  .project-pub-link { flex-direction: column; gap: 0.2rem; }
+  .project-pub-meta { white-space: normal; }
+}

--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -11,7 +11,7 @@ main:
     url: /publication/
     weight: 12
   - name: Projects
-    url: /projects/
+    url: /project/
     weight: 20
   - name: Meanwhile
     url: /meanwhile/

--- a/content/project/_index.md
+++ b/content/project/_index.md
@@ -1,0 +1,5 @@
+---
+title: Projects
+description: Research I'm actively building and themes that run across multiple publications.
+type: project
+---

--- a/content/project/ai-red-teaming/index.md
+++ b/content/project/ai-red-teaming/index.md
@@ -1,0 +1,15 @@
+---
+title: "AI Red Teaming & Scalable Evaluation"
+summary: "Who does the work of keeping AI systems safe? This line of research examines the human labor behind AI red teaming and safety evaluation — who is hired to stress-test models, how their work is structured, and what gets lost when evaluation is automated at scale."
+status: theme
+date: 2024-01-01
+tags:
+  - AI Safety
+  - Crowdwork
+  - Human-AI Interaction
+related_pubs:
+  - qian-2024-the
+  - qian-2025-the
+  - qian-2026-human
+  - choong-2026-towards
+---

--- a/content/project/current-project-example/index.md
+++ b/content/project/current-project-example/index.md
@@ -1,0 +1,9 @@
+---
+title: "Add a Current Project Here"
+summary: "Replace this with a description of something you're actively working on that doesn't yet have a publication. This could be a new study, a tool you're building, or an early-stage research direction."
+status: active
+date: 2025-01-01
+tags:
+  - Tag One
+  - Tag Two
+---

--- a/layouts/project/list.html
+++ b/layouts/project/list.html
@@ -1,0 +1,91 @@
+{{ define "main" }}
+<section class="projects-page">
+
+  <div class="projects-header">
+    <h1 class="projects-title">{{ .Title }}</h1>
+    {{ with .Description }}<p class="projects-subtitle">{{ . }}</p>{{ end }}
+  </div>
+
+  {{/* ── Current Work ───────────────────────────────────────────────────── */}}
+  {{ $active := where .Pages "Params.status" "active" }}
+  {{ if $active }}
+  <div class="projects-section">
+    <h2 class="projects-section-label">Current Work</h2>
+    <p class="projects-section-desc">In progress — no publication yet.</p>
+    <div class="projects-active-grid">
+      {{ range $active.ByDate.Reverse }}
+      <div class="project-active-card">
+        {{ with .Resources.GetMatch "featured*" }}
+        <div class="project-card-image">
+          <img src="{{ .RelPermalink }}" alt="{{ $.Title }}" loading="lazy">
+        </div>
+        {{ end }}
+        <div class="project-card-body">
+          <div class="project-card-tags">
+            {{ range .Params.tags }}<span class="project-tag">{{ . }}</span>{{ end }}
+          </div>
+          <h3 class="project-card-title">{{ .Title }}</h3>
+          <p class="project-card-summary">{{ .Params.summary }}</p>
+        </div>
+        <span class="project-status-badge">Active</span>
+      </div>
+      {{ end }}
+    </div>
+  </div>
+  {{ end }}
+
+  {{/* ── Research Themes ─────────────────────────────────────────────────── */}}
+  {{ $themes := where .Pages "Params.status" "theme" }}
+  {{ if $themes }}
+  <div class="projects-section">
+    <h2 class="projects-section-label">Research Themes</h2>
+    <p class="projects-section-desc">Lines of inquiry spanning multiple publications.</p>
+    <div class="projects-themes-list">
+      {{ range $themes.ByDate.Reverse }}
+      {{ $theme := . }}
+      <div class="project-theme">
+        <div class="project-theme-header">
+          {{ with .Resources.GetMatch "featured*" }}
+          <div class="project-theme-image">
+            <img src="{{ .RelPermalink }}" alt="{{ $theme.Title }}" loading="lazy">
+          </div>
+          {{ end }}
+          <div class="project-theme-meta">
+            <div class="project-card-tags">
+              {{ range .Params.tags }}<span class="project-tag">{{ . }}</span>{{ end }}
+            </div>
+            <h3 class="project-theme-title">{{ .Title }}</h3>
+            <p class="project-theme-summary">{{ .Params.summary }}</p>
+          </div>
+        </div>
+
+        {{/* Linked publications */}}
+        {{ with .Params.related_pubs }}
+        <div class="project-theme-pubs">
+          {{ range . }}
+          {{ $slug := . }}
+          {{ $pub := index (where site.RegularPages "File.Dir" (printf "publication/%s/" $slug)) 0 }}
+          {{ with $pub }}
+          <a class="project-pub-link" href="{{ .RelPermalink }}">
+            <span class="project-pub-title">{{ .Title }}</span>
+            <span class="project-pub-meta">
+              {{ with .Params.publication_types }}
+                {{ $t := index . 0 }}
+                {{ if eq $t "article-journal" }}Journal{{ else if eq $t "paper-conference" }}Conference{{ else if eq $t "chapter" }}Workshop{{ else if eq $t "manuscript" }}Preprint{{ end }}
+              {{ end }}
+              {{ if .Date }}· {{ .Date.Format "2006" }}{{ end }}
+            </span>
+          </a>
+          {{ end }}
+          {{ end }}
+        </div>
+        {{ end }}
+
+      </div>
+      {{ end }}
+    </div>
+  </div>
+  {{ end }}
+
+</section>
+{{ end }}


### PR DESCRIPTION
## Summary

- New `/project/` section replacing the old Hugo Blox landing page at `/projects/`
- Custom list template splits projects into two sections based on a `status` frontmatter field:
  - **Current Work** (`status: active`) — card grid for in-progress research with no publications yet
  - **Research Themes** (`status: theme`) — stacked entries for multi-paper lines of inquiry, each showing linked publication titles with type badge and year
- Includes an example research theme ("AI Red Teaming & Evaluation") pre-linked to 4 publications as a reference
- Includes a placeholder active project card to copy
- Nav updated from `/projects/` → `/project/`

## How to add a project

Create `content/project/<slug>/index.md`:

```yaml
---
title: "Project Name"
summary: "One paragraph description."
status: active        # or: theme
date: 2025-01-01
tags:
  - Tag One
related_pubs:          # only needed for status: theme
  - publication-slug
---
```

Optionally drop a `featured.jpg` in the folder for a cover image.

## Test plan

- [ ] `/project/` renders with both sections visible
- [ ] Research theme shows linked paper titles, types, and years
- [ ] Active project card shows with green "Active" badge
- [ ] Nav "Projects" link goes to `/project/`
- [ ] Mobile layout collapses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_