### PR TITLE
fix: remove outer container width constraint squeezing bio sections

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,8 +1,21 @@
-/* ── Break Hugo Blox prose width limits for bio blocks ──────────────────── */
+/* ── Break Hugo Blox width constraints for bio/info sections ────────────── */
+/*
+ * Hugo Blox wraps each markdown block in an outer container div
+ * (article-container / max-w-7xl etc.) that sits ABOVE .prose.
+ * We must remove max-width at every ancestor level, not just on .prose.
+ */
+#bio,
+#info {
+  width: 100%;
+}
 
-#bio .prose,
-#info .prose {
-  max-width: none;
+#bio > *,
+#bio > * > *,
+#info > *,
+#info > * > * {
+  max-width: none !important;
+  width: 100% !important;
+  box-sizing: border-box;
 }
 
 /* ── Homepage hero (photo + bio) ────────────────────────────────────────── */


### PR DESCRIPTION
## Problem

Both the profile column and the bio text feel too narrow. The previous fix (`#bio .prose { max-width: none }`) only removed the Tailwind typography constraint on the `.prose` element itself, but Hugo Blox also wraps each markdown block in an **outer container div** (sitting above `.prose`) that has its own `max-width` — typically around 720px. That container was the real bottleneck.

## Fix

Target all ancestor wrapper levels inside `#bio` and `#info` (not just `.prose`) to ensure no max-width is inherited from the theme's container:

```css
#bio > *, #bio > * > *,
#info > *, #info > * > * {
  max-width: none !important;
  width: 100% !important;
}
```

This is based on `claude/homepage-layout-condensed` (PR #20) and should be merged after that PR lands.

## Test plan

- [ ] Bio text (right column) no longer looks squeezed — fills the space comfortably
- [ ] Profile column (left) still renders as intended
- [ ] Education + Interests row below also uses full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_