### PR TITLE
feat: typography overhaul, remove dividers/badges, fix nav

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,3 +1,24 @@
+/* ── Typography: Lora (serif display) + DM Sans (body) ─────────────────── */
+@import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300;1,9..40,400&display=swap');
+
+body {
+  font-family: 'DM Sans', system-ui, -apple-system, sans-serif;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Lora', Georgia, serif;
+}
+
+/* Nav and UI chrome stay sans */
+nav, .navbar, header,
+.pub-badge, .pub-btn, .pub-authors, .pub-venue,
+.hero-links, .hero-cv-btn, .hero-role,
+.bio-section-heading, .bio-edu-institution, .bio-edu-years,
+.pub-single-authors, .pub-single-venue, .pub-single-date,
+.pub-single-section-label, .pub-single-back {
+  font-family: 'DM Sans', system-ui, sans-serif;
+}
+
 /* ── Break Hugo Blox width constraints for bio/info sections ────────────── */
 /*
  * Hugo Blox wraps each markdown block in an outer container div
@@ -148,11 +169,8 @@
 .bio-news-list li {
   font-size: 0.84rem;
   line-height: 1.55;
-  padding: 0.4rem 0;
-  border-bottom: 1px solid rgba(128, 128, 128, 0.12);
+  padding: 0.25rem 0;
 }
-
-.bio-news-list li:last-child { border-bottom: none; }
 
 /* Education list */
 .bio-education-list {
@@ -226,14 +244,13 @@
 }
 
 .pub-year-label {
-  font-size: 0.72rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
+  font-family: 'Lora', Georgia, serif;
+  font-size: 1.5rem;
+  font-style: italic;
+  font-weight: 400;
   opacity: 0.35;
   margin: 0 0 1.25rem;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid rgba(128, 128, 128, 0.15);
+  letter-spacing: -0.01em;
 }
 
 .pub-year-list {
@@ -282,22 +299,20 @@
   flex-wrap: wrap;
 }
 
-/* Type badges */
+/* Type badges — plain text labels, no colored backgrounds */
 .pub-badge {
   font-size: 0.65rem;
-  font-weight: 600;
+  font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 0.15rem 0.5rem;
-  border-radius: 3px;
+  letter-spacing: 0.1em;
+  opacity: 0.45;
   flex-shrink: 0;
+  padding: 0;
+  border-radius: 0;
 }
 
-.badge-journal    { background: rgba(99, 102, 241, 0.15); color: #818cf8; }
-.badge-conference { background: rgba(34, 197, 94, 0.12);  color: #4ade80; }
-.badge-workshop   { background: rgba(251, 146, 60, 0.12); color: #fb923c; }
-.badge-preprint   { background: rgba(148, 163, 184, 0.12); color: #94a3b8; }
-.badge-other      { background: rgba(148, 163, 184, 0.1);  color: #94a3b8; }
+.badge-journal, .badge-conference, .badge-workshop,
+.badge-preprint, .badge-other { background: none; color: inherit; }
 
 .pub-venue {
   font-size: 0.78rem;
@@ -434,8 +449,7 @@
 
 .pub-single-back {
   margin-top: 3rem;
-  padding-top: 1.5rem;
-  border-top: 1px solid rgba(128,128,128,0.15);
+  padding-top: 0;
 }
 
 .pub-single-back a {

--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -11,7 +11,7 @@ main:
     url: /publication/
     weight: 12
   - name: Projects
-    url: /projects/
+    url: /project/
     weight: 20
   - name: Meanwhile
     url: /meanwhile/

--- a/content/_index.md
+++ b/content/_index.md
@@ -31,10 +31,10 @@ sections:
             <div class="hero-news">
               <h3 class="bio-section-heading">Recent News</h3>
               <ul class="bio-news-list">
-                <li><strong>May 2025</strong> — Paper accepted at CSCW 2025: "AURA: Supporting Responsible AI Content Work"</li>
-                <li><strong>Apr 2025</strong> — Presented at CHI 2025 workshop on AI safety and red teaming</li>
-                <li><strong>Sep 2024</strong> — Started Ph.D. at Carnegie Mellon University HCII</li>
-                <li><strong>May 2024</strong> — Graduated with B.S. Computer Science from University of Minnesota</li>
+                <li><strong>May 2025.</strong> Paper accepted at CSCW 2025: "AURA: Supporting Responsible AI Content Work"</li>
+                <li><strong>Apr 2025.</strong> Presented at CHI 2025 workshop on AI safety and red teaming</li>
+                <li><strong>Sep 2024.</strong> Started Ph.D. at Carnegie Mellon University HCII</li>
+                <li><strong>May 2024.</strong> Graduated with B.S. Computer Science from University of Minnesota</li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
## What changed

### Typography
- **Lora** (literary serif) for all headings and display text — year labels on the publication list, publication titles, page titles
- **DM Sans** (clean geometric sans) for body text, metadata, nav links — replaces the system default that reads as generic/AI-adjacent
- Year labels on the pub list become large italic Lora numerals instead of small-caps with a divider line

### Divider lines removed
- News list items no longer have `border-bottom` between each item
- Publication year labels no longer have `border-bottom`
- Single pub page back link no longer has `border-top`

### Badge redesign
- Colored background blocks (indigo/green/orange) on pub type labels removed
- Now rendered as plain uppercase text at low opacity — still legible as type labels, doesn't look like highlighted call-out blocks

### Nav
- Fixed Projects URL from `/projects/` (old landing page) to `/project/` (new two-section page)

### News items
- Removed em dashes (`—`) between date and text; now uses a period after the bold date

---

This PR is based on `claude/fix-bio-width-v2` (PR #23) which is based on `claude/homepage-layout-condensed` (PR #20). Merge order: #20 → #23 → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_