### PR TITLE
feat: homepage layout v2, Lora everywhere, crimson palette

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,52 +1,39 @@
-/* ── Typography: Lora (serif display) + DM Sans (body) ─────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300;1,9..40,400&display=swap');
-
-body {
-  font-family: 'DM Sans', system-ui, -apple-system, sans-serif;
+/* ── Brand colors ────────────────────────────────────────────────────────── */
+:root {
+  --crimson: #C41E56;
+  --crimson-soft: rgba(196, 30, 86, 0.45);
+  --crimson-subtle: rgba(196, 30, 86, 0.1);
+  --pale-gray: #DCDCDC;
 }
 
-h1, h2, h3, h4, h5, h6 {
+/* ── Typography: Lora only ───────────────────────────────────────────────── */
+@import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&display=swap');
+
+body, * {
   font-family: 'Lora', Georgia, serif;
 }
 
-/* Nav and UI chrome stay sans */
-nav, .navbar, header,
-.pub-badge, .pub-btn, .pub-authors, .pub-venue,
-.hero-links, .hero-cv-btn, .hero-role,
-.bio-section-heading, .bio-edu-institution, .bio-edu-years,
-.pub-single-authors, .pub-single-venue, .pub-single-date,
-.pub-single-section-label, .pub-single-back {
-  font-family: 'DM Sans', system-ui, sans-serif;
-}
-
-/* ── Break Hugo Blox width constraints for bio/info sections ────────────── */
-/*
- * Hugo Blox wraps each markdown block in an outer container div
- * (article-container / max-w-7xl etc.) that sits ABOVE .prose.
- * We must remove max-width at every ancestor level, not just on .prose.
- */
-#bio,
-#info {
-  width: 100%;
-}
-
-#bio > *,
-#bio > * > *,
-#info > *,
-#info > * > * {
+/* ── Break Hugo Blox container max-width (remove constraint, not force width) */
+#bio > *, #bio > * > *,
+#info > *, #info > * > * {
   max-width: none !important;
-  width: 100% !important;
-  box-sizing: border-box;
 }
 
 /* ── Homepage hero (photo + bio) ────────────────────────────────────────── */
-
+/*
+ * Controlled breakout: wider than Hugo Blox's article container but not
+ * full-bleed. `left: 50% + translateX(-50%)` centers on the viewport.
+ * `min(1000px, …)` caps width so it doesn't stretch on very wide screens.
+ */
 .homepage-hero {
   display: grid;
-  grid-template-columns: 200px 1fr;
-  gap: 3rem;
+  grid-template-columns: 180px 1fr;
+  gap: 2.5rem;
   align-items: start;
-  width: 100%;
+  width: min(1000px, calc(100vw - 4rem));
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .hero-avatar {
@@ -115,10 +102,6 @@ nav, .navbar, header,
 
 .hero-cv-btn:hover { opacity: 1; }
 
-.hero-news {
-  margin-top: 0;
-}
-
 .hero-right {
   padding-top: 0.25rem;
 }
@@ -141,13 +124,17 @@ nav, .navbar, header,
   .hero-cv-btn { text-align: left; display: inline-block; }
 }
 
-/* ── Homepage bio info row (education + interests) ──────────────────────── */
+/* ── Homepage info row (news | education | interests) ───────────────────── */
 
 .bio-info-row {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 3rem;
-  width: 100%;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 2.5rem;
+  width: min(1000px, calc(100vw - 4rem));
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+  padding-top: 0.5rem;
 }
 
 .bio-section-heading {
@@ -217,7 +204,7 @@ nav, .navbar, header,
   padding: 0.2rem 0;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 768px) {
   .bio-info-row {
     grid-template-columns: 1fr;
     gap: 2rem;
@@ -227,9 +214,9 @@ nav, .navbar, header,
 /* ── Publications list page ─────────────────────────────────────────────── */
 
 .pub-list-page {
-  max-width: 860px;
+  max-width: 1000px;
   margin: 0 auto;
-  padding: 3rem 1.5rem 5rem;
+  padding: 3rem clamp(1.5rem, 5vw, 3rem) 5rem;
 }
 
 .pub-list-title {
@@ -299,20 +286,23 @@ nav, .navbar, header,
   flex-wrap: wrap;
 }
 
-/* Type badges — plain text labels, no colored backgrounds */
+/* Type badges */
 .pub-badge {
   font-size: 0.65rem;
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  opacity: 0.45;
   flex-shrink: 0;
   padding: 0;
-  border-radius: 0;
+  background: none;
+  color: var(--crimson);
+  opacity: 0.7;
 }
 
-.badge-journal, .badge-conference, .badge-workshop,
-.badge-preprint, .badge-other { background: none; color: inherit; }
+.badge-preprint, .badge-other {
+  color: var(--pale-gray);
+  opacity: 0.55;
+}
 
 .pub-venue {
   font-size: 0.78rem;
@@ -362,8 +352,9 @@ nav, .navbar, header,
 
 .pub-btn:hover { opacity: 1; }
 
-.pub-btn-pdf   { border-color: rgba(99, 102, 241, 0.35); }
-.pub-btn-video { border-color: rgba(251, 146, 60, 0.35); }
+.pub-btn-pdf   { border-color: var(--crimson-soft); }
+.pub-btn-video { border-color: var(--crimson-soft); }
+.pub-btn:hover { border-color: var(--crimson); opacity: 1; }
 
 @media (max-width: 600px) {
   .pub-entry.has-thumb {
@@ -855,9 +846,9 @@ a.meanwhile-cell:hover .cell-arrow {
   text-transform: uppercase;
   padding: 0.2rem 0.55rem;
   border-radius: 20px;
-  background: rgba(34, 197, 94, 0.15);
-  color: rgb(34, 197, 94);
-  border: 1px solid rgba(34, 197, 94, 0.3);
+  background: var(--crimson-subtle);
+  color: var(--crimson);
+  border: 1px solid var(--crimson-soft);
 }
 
 /* ── Research theme entries ───────────────────────────────────────────── */

--- a/content/_index.md
+++ b/content/_index.md
@@ -28,15 +28,6 @@ sections:
               <a href="https://orcid.org/0009-0005-6407-6981">ORCID</a>
             </nav>
             <a href="/uploads/resume.pdf" class="hero-cv-btn">Download CV →</a>
-            <div class="hero-news">
-              <h3 class="bio-section-heading">Recent News</h3>
-              <ul class="bio-news-list">
-                <li><strong>May 2025.</strong> Paper accepted at CSCW 2025: "AURA: Supporting Responsible AI Content Work"</li>
-                <li><strong>Apr 2025.</strong> Presented at CHI 2025 workshop on AI safety and red teaming</li>
-                <li><strong>Sep 2024.</strong> Started Ph.D. at Carnegie Mellon University HCII</li>
-                <li><strong>May 2024.</strong> Graduated with B.S. Computer Science from University of Minnesota</li>
-              </ul>
-            </div>
           </div>
           <div class="hero-right">
             <p>Hi! I am a Ph.D. student in the Human-Computer Interaction Institute (HCII) at Carnegie Mellon University advised by <a href="https://www.hcii.cmu.edu/people/hong-shen">Hong Shen</a> and <a href="https://www.lauradabbish.com/">Laura Dabbish</a>. I collaborated with <a href="https://www.jinasuh.com/">Jina Suh</a>, <a href="https://marylgray.org/">Mary L. Gray</a>, and <a href="https://ischool.uw.edu/people/faculty/profile/marycz">Mary Czerwinski</a> at Microsoft Research on research focused on identifying and addressing AI harms through red teaming.</p>
@@ -55,6 +46,15 @@ sections:
       title: ""
       text: |-
         <div class="bio-info-row">
+          <div class="bio-col bio-col-news">
+            <h3 class="bio-section-heading">Recent News</h3>
+            <ul class="bio-news-list">
+              <li><strong>May 2025.</strong> Paper accepted at CSCW 2025: "AURA: Supporting Responsible AI Content Work"</li>
+              <li><strong>Apr 2025.</strong> Presented at CHI 2025 workshop on AI safety and red teaming</li>
+              <li><strong>Sep 2024.</strong> Started Ph.D. at Carnegie Mellon University HCII</li>
+              <li><strong>May 2024.</strong> Graduated with B.S. Computer Science from University of Minnesota</li>
+            </ul>
+          </div>
           <div class="bio-col bio-col-education">
             <h3 class="bio-section-heading">Education</h3>
             <ul class="bio-education-list">


### PR DESCRIPTION
## What changed

### Layout
- **News moved to bottom row** — no longer buried under the profile photo. Bottom row is now 3 equal columns: **News | Education | Interests**
- **Profile column** is clean: photo, name, role, links, CV button only
- **Controlled width**: hero and info row use `min(1000px, calc(100vw - 4rem))` with a centered breakout — wide enough to feel spacious, not edge-to-edge like before
- **Profile column** narrowed to 180px (was 200px) for a better bio/profile ratio

### Typography
- **Single font: Lora** everywhere — headings, body, nav, UI elements, metadata
- Removed DM Sans entirely

### Color palette: black / crimson / gray
- `--crimson: #C41E56` — pub type badges (Journal, Conference, Workshop), button borders on hover, project Active badge
- `--pale-gray: #DCDCDC` — Preprint and other secondary badges  
- Removed old indigo/orange button border colors

### Publications
- Pub list page widened from 860px → 1000px to match homepage content width

## Test plan
- [ ] Homepage: profile photo centered in left column, bio text fills right column comfortably
- [ ] Below bio: three columns — News / Education / Interests — all visible side by side
- [ ] Font reads as Lora (serif) throughout, consistent
- [ ] Publication type labels show in crimson; Preprint shows in gray
- [ ] `/publication/` list page width matches homepage proportions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_