### PR TITLE
Fix publication ordering: show most recent year first

### DIFF
--- a/layouts/publication/list.html
+++ b/layouts/publication/list.html
@@ -7,7 +7,7 @@
   {{ $pubs := where site.RegularPages "Section" "publication" }}
   {{ $pubs = where $pubs "Params.draft" "ne" true }}
 
-  {{ range ($pubs.GroupByDate "2006").Reverse }}
+  {{ range $pubs.GroupByDate "2006" }}
   <div class="pub-year-group">
     <h2 class="pub-year-label">{{ .Key }}</h2>
     <div class="pub-year-list">


### PR DESCRIPTION
## Summary

- `GroupByDate "2006"` returns year groups newest-first by default
- The previous `.Reverse` call was flipping this to oldest-first (2024 before 2025/2026)
- Removing `.Reverse` restores the correct descending order

## Test plan
- [ ] Publications page shows 2026 papers first, then 2025, 2024, etc.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_