### PR TITLE
New color palette + editorial projects + magazine meanwhile

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,30 +1,28 @@
-/* ── Typography: Lora (serif display) + DM Sans (body) ─────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300;1,9..40,400&display=swap');
-
-body {
-  font-family: 'DM Sans', system-ui, -apple-system, sans-serif;
+/* ── Color palette ───────────────────────────────────────────────────────── */
+:root {
+  --bg:            #F2EDE4;          /* cream — page background              */
+  --teal:          #6DCBD5;          /* primary accent                       */
+  --teal-soft:     rgba(109,203,213,0.35);
+  --teal-subtle:   rgba(109,203,213,0.12);
+  --coral:         #E05A4E;          /* secondary accent / active            */
+  --coral-soft:    rgba(224,90,78,0.35);
+  --deep-purple:   #3C1A5B;          /* dark accent / section headers        */
+  --text:          #1a1a1a;          /* body text — near-black on cream      */
 }
 
-h1, h2, h3, h4, h5, h6 {
+/* ── Typography: Lora only ───────────────────────────────────────────────── */
+@import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&display=swap');
+
+body, * {
   font-family: 'Lora', Georgia, serif;
 }
 
-/* Nav and UI chrome stay sans */
-nav, .navbar, header,
-.pub-badge, .pub-btn, .pub-authors, .pub-venue,
-.hero-links, .hero-cv-btn, .hero-role,
-.bio-section-heading, .bio-edu-institution, .bio-edu-years,
-.pub-single-authors, .pub-single-venue, .pub-single-date,
-.pub-single-section-label, .pub-single-back {
-  font-family: 'DM Sans', system-ui, sans-serif;
+body {
+  background-color: var(--bg);
+  color: var(--text);
 }
 
-/* ── Break Hugo Blox width constraints for bio/info sections ────────────── */
-/*
- * Hugo Blox wraps each markdown block in an outer container div
- * (article-container / max-w-7xl etc.) that sits ABOVE .prose.
- * We must remove max-width at every ancestor level, not just on .prose.
- */
+/* ── Break Hugo Blox width constraints for bio/info sections ─────────────── */
 #bio,
 #info {
   width: 100%;
@@ -39,7 +37,7 @@ nav, .navbar, header,
   box-sizing: border-box;
 }
 
-/* ── Homepage hero (photo + bio) ────────────────────────────────────────── */
+/* ── Homepage hero (photo + bio) ─────────────────────────────────────────── */
 
 .homepage-hero {
   display: grid;
@@ -91,29 +89,35 @@ nav, .navbar, header,
 .hero-links a {
   font-size: 0.74rem;
   padding: 0.18rem 0.5rem;
-  border: 1px solid rgba(128, 128, 128, 0.25);
+  border: 1px solid var(--teal-soft);
   border-radius: 3px;
   text-decoration: none;
-  opacity: 0.6;
-  transition: opacity 0.15s;
+  opacity: 0.7;
+  transition: opacity 0.15s, border-color 0.15s;
 }
 
-.hero-links a:hover { opacity: 1; }
+.hero-links a:hover {
+  opacity: 1;
+  border-color: var(--teal);
+}
 
 .hero-cv-btn {
   display: block;
   text-align: center;
   font-size: 0.78rem;
   padding: 0.35rem 0.6rem;
-  border: 1px solid rgba(128, 128, 128, 0.3);
+  border: 1px solid var(--teal-soft);
   border-radius: 4px;
   margin-bottom: 2rem;
   text-decoration: none;
-  opacity: 0.55;
-  transition: opacity 0.15s;
+  opacity: 0.65;
+  transition: opacity 0.15s, border-color 0.15s;
 }
 
-.hero-cv-btn:hover { opacity: 1; }
+.hero-cv-btn:hover {
+  opacity: 1;
+  border-color: var(--teal);
+}
 
 .hero-news {
   margin-top: 0;
@@ -141,7 +145,7 @@ nav, .navbar, header,
   .hero-cv-btn { text-align: left; display: inline-block; }
 }
 
-/* ── Homepage bio info row (education + interests) ──────────────────────── */
+/* ── Homepage info row (education + interests) ───────────────────────────── */
 
 .bio-info-row {
   display: grid;
@@ -155,11 +159,12 @@ nav, .navbar, header,
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  opacity: 0.45;
+  color: var(--deep-purple);
+  opacity: 0.55;
   margin: 0 0 0.85rem;
 }
 
-/* News list (used in hero-left) */
+/* News list */
 .bio-news-list {
   list-style: none;
   padding: 0;
@@ -224,7 +229,7 @@ nav, .navbar, header,
   }
 }
 
-/* ── Publications list page ─────────────────────────────────────────────── */
+/* ── Publications list page ──────────────────────────────────────────────── */
 
 .pub-list-page {
   max-width: 860px;
@@ -248,7 +253,8 @@ nav, .navbar, header,
   font-size: 1.5rem;
   font-style: italic;
   font-weight: 400;
-  opacity: 0.35;
+  color: var(--deep-purple);
+  opacity: 0.4;
   margin: 0 0 1.25rem;
   letter-spacing: -0.01em;
 }
@@ -299,24 +305,49 @@ nav, .navbar, header,
   flex-wrap: wrap;
 }
 
-/* Type badges — plain text labels, no colored backgrounds */
+/* Type badges — colored, fully readable */
 .pub-badge {
   font-size: 0.65rem;
-  font-weight: 500;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  opacity: 0.45;
   flex-shrink: 0;
-  padding: 0;
-  border-radius: 0;
+  padding: 0.15rem 0.5rem;
+  border-radius: 2px;
+  background: none;
+  border: 1px solid transparent;
 }
 
-.badge-journal, .badge-conference, .badge-workshop,
-.badge-preprint, .badge-other { background: none; color: inherit; }
+.badge-conference {
+  color: var(--teal);
+  border-color: var(--teal-soft);
+}
+
+.badge-journal {
+  color: var(--deep-purple);
+  border-color: rgba(60,26,91,0.3);
+}
+
+.badge-workshop {
+  color: var(--coral);
+  border-color: var(--coral-soft);
+}
+
+.badge-preprint {
+  color: var(--text);
+  opacity: 0.45;
+  border-color: rgba(128,128,128,0.25);
+}
+
+.badge-other {
+  color: var(--text);
+  opacity: 0.4;
+  border-color: rgba(128,128,128,0.2);
+}
 
 .pub-venue {
   font-size: 0.78rem;
-  opacity: 0.45;
+  opacity: 0.5;
   font-style: italic;
 }
 
@@ -332,7 +363,7 @@ nav, .navbar, header,
 }
 
 .pub-title a:hover {
-  text-decoration: underline;
+  color: var(--teal);
 }
 
 .pub-authors {
@@ -355,15 +386,19 @@ nav, .navbar, header,
   padding: 0.2rem 0.65rem;
   border-radius: 3px;
   text-decoration: none;
-  border: 1px solid rgba(128, 128, 128, 0.25);
-  opacity: 0.65;
-  transition: opacity 0.15s;
+  border: 1px solid rgba(128,128,128,0.25);
+  opacity: 0.7;
+  transition: opacity 0.15s, border-color 0.15s;
 }
 
 .pub-btn:hover { opacity: 1; }
 
-.pub-btn-pdf   { border-color: rgba(99, 102, 241, 0.35); }
-.pub-btn-video { border-color: rgba(251, 146, 60, 0.35); }
+.pub-btn-pdf   { border-color: var(--teal-soft); color: var(--teal); }
+.pub-btn-video { border-color: var(--coral-soft); color: var(--coral); }
+.pub-btn-cite  { border-color: rgba(128,128,128,0.25); }
+
+.pub-btn-pdf:hover   { border-color: var(--teal); }
+.pub-btn-video:hover { border-color: var(--coral); }
 
 @media (max-width: 600px) {
   .pub-entry.has-thumb {
@@ -411,7 +446,7 @@ nav, .navbar, header,
 
 .pub-single-venue {
   font-size: 0.82rem;
-  opacity: 0.45;
+  opacity: 0.5;
   font-style: italic;
   margin: 0 0 1.25rem;
 }
@@ -443,13 +478,13 @@ nav, .navbar, header,
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  opacity: 0.4;
+  color: var(--deep-purple);
+  opacity: 0.45;
   margin: 0 0 0.75rem;
 }
 
 .pub-single-back {
   margin-top: 3rem;
-  padding-top: 0;
 }
 
 .pub-single-back a {
@@ -460,501 +495,466 @@ nav, .navbar, header,
 
 .pub-single-back a:hover {
   opacity: 1;
+  color: var(--teal);
 }
 
-/* ── Meanwhile page ─────────────────────────────────────────────────────── */
-
-.meanwhile-page {
-  max-width: 1400px;
-  margin: 0 auto;
-  padding: 4rem 2rem 6rem;
-}
-
-.meanwhile-header {
-  text-align: center;
-  margin-bottom: 3rem;
-}
-
-.meanwhile-title {
-  font-size: clamp(2.5rem, 5vw, 4rem);
-  font-weight: 700;
-  letter-spacing: -0.03em;
-  margin: 0 0 0.5rem;
-  line-height: 1.1;
-}
-
-.meanwhile-subtitle {
-  font-size: 1.125rem;
-  opacity: 0.5;
-  margin: 0;
-}
-
-/* ── Grid ────────────────────────────────────────────────────────────────── */
-
-.meanwhile-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  grid-auto-flow: dense;
-  gap: 0.75rem;
-}
-
-/* ── Cell base ───────────────────────────────────────────────────────────── */
-
-.meanwhile-cell {
-  overflow: hidden;
-  position: relative;
-  min-height: 180px;
-  /* No universal border-radius — each type sets its own */
-}
-
-a.meanwhile-cell {
-  text-decoration: none;
-  color: inherit;
-  display: flex;
-  flex-direction: column;
-}
-
-/* Hover: subtle opacity shift instead of lifting card */
-a.meanwhile-cell {
-  transition: opacity 0.15s ease;
-}
-a.meanwhile-cell:hover {
-  opacity: 0.88;
-}
-
-/* ── Sizes ───────────────────────────────────────────────────────────────── */
-
-.size-small  { grid-column: span 1; grid-row: span 1; min-height: 180px; }
-.size-medium { grid-column: span 2; grid-row: span 1; min-height: 220px; }
-.size-large  { grid-column: span 2; grid-row: span 2; min-height: 460px; }
-.size-hero   { grid-column: span 3; grid-row: span 2; min-height: 460px; }
-
-/* ── Text cell ───────────────────────────────────────────────────────────── */
-
-/* Default background if no color is set in YAML */
-.type-text {
-  background: #1c1c27;
-  border-radius: 6px;
-  padding: 1.75rem 1.75rem 1.5rem;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-}
-
-/* The text itself — large, confident, no decorative borders */
-.cell-text-body {
-  font-size: clamp(1.05rem, 1.6vw, 1.35rem);
-  line-height: 1.55;
-  font-weight: 500;
-  margin: 0 0 0.6rem;
-  color: rgba(255, 255, 255, 0.92);
-}
-
-.cell-attribution {
-  font-size: 0.78rem;
-  opacity: 0.45;
-  font-style: italic;
-}
-
-/* ── Image cell ──────────────────────────────────────────────────────────── */
-
-/* Sharp corners — images feel raw and editorial without radius */
-.type-image {
-  background: #111;
-  border-radius: 0;
-}
-
-.type-image img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
-.type-image .cell-caption {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 0.75rem 1rem;
-  background: linear-gradient(transparent, rgba(0, 0, 0, 0.7));
-  font-size: 0.82rem;
-  color: rgba(255, 255, 255, 0.8);
-}
-
-/* ── Link cell ───────────────────────────────────────────────────────────── */
-
-.type-link {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  border-radius: 6px;
-}
-
-.type-link > img {
-  width: 100%;
-  height: 140px;
-  object-fit: cover;
-  flex-shrink: 0;
-  border-radius: 0; /* image inside goes edge-to-edge */
-}
-
-.cell-link-body {
-  padding: 1.1rem 1.25rem 1.25rem;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-}
-
-.cell-source {
-  display: block;
-  font-size: 0.68rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  opacity: 0.4;
-  margin-bottom: 0.45rem;
-}
-
-.cell-link-body h3 {
-  font-size: 0.97rem;
-  font-weight: 600;
-  line-height: 1.4;
-  margin: 0 0 0.4rem;
-}
-
-.cell-link-body p {
-  font-size: 0.83rem;
-  opacity: 0.52;
-  margin: 0;
-  line-height: 1.5;
-}
-
-/* ── Video cell ──────────────────────────────────────────────────────────── */
-
-.type-video {
-  background: #000;
-  border-radius: 0; /* raw, like an image */
-  display: flex;
-  flex-direction: column;
-}
-
-.cell-video-wrapper {
-  flex: 1;
-  position: relative;
-  min-height: 160px;
-}
-
-.cell-video-wrapper iframe {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  border: none;
-}
-
-.cell-caption {
-  padding: 0.55rem 1rem;
-  font-size: 0.8rem;
-  opacity: 0.45;
-  background: rgba(0, 0, 0, 0.5);
-  flex-shrink: 0;
-}
-
-/* ── Project cell ────────────────────────────────────────────────────────── */
-
-.type-project {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  border-radius: 6px;
-}
-
-.type-project > img {
-  width: 100%;
-  height: 55%;
-  object-fit: cover;
-  flex-shrink: 0;
-  border-radius: 0;
-}
-
-.cell-project-body {
-  padding: 1.1rem 1.25rem 1.25rem;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-}
-
-.cell-tag {
-  display: block;
-  font-size: 0.68rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  opacity: 0.55;
-  margin-bottom: 0.45rem;
-}
-
-.cell-project-body h3 {
-  font-size: 1rem;
-  font-weight: 600;
-  margin: 0 0 0.4rem;
-  line-height: 1.3;
-}
-
-.cell-project-body p {
-  font-size: 0.83rem;
-  opacity: 0.52;
-  margin: 0;
-  line-height: 1.5;
-}
-
-/* ── Arrow indicator ─────────────────────────────────────────────────────── */
-
-.cell-arrow {
-  position: absolute;
-  top: 0.9rem;
-  right: 0.9rem;
-  font-size: 0.9rem;
-  opacity: 0.25;
-  transition: opacity 0.15s;
-}
-
-a.meanwhile-cell:hover .cell-arrow {
-  opacity: 0.7;
-}
-
-/* ── Responsive ──────────────────────────────────────────────────────────── */
-
-@media (max-width: 1200px) {
-  .meanwhile-grid { grid-template-columns: repeat(3, 1fr); }
-  .size-hero { grid-column: span 3; }
-}
-
-@media (max-width: 768px) {
-  .meanwhile-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
-  .size-hero { grid-column: span 2; }
-  .meanwhile-page { padding: 2rem 1rem 4rem; }
-}
-
-@media (max-width: 480px) {
-  .meanwhile-grid { grid-template-columns: 1fr; }
-  .meanwhile-cell { grid-column: span 1 !important; grid-row: span 1 !important; }
-}
-
-/* ── Projects page ───────────────────────────────────────────────────────── */
+/* ── Projects page — two-column editorial ────────────────────────────────── */
 
 .projects-page {
   max-width: 860px;
   margin: 0 auto;
-  padding: 3rem 1.5rem 5rem;
-}
-
-.projects-header {
-  margin-bottom: 3.5rem;
+  padding: 3rem 1.5rem 6rem;
 }
 
 .projects-title {
-  font-size: clamp(1.8rem, 4vw, 2.8rem);
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  font-weight: 600;
+  font-style: italic;
   margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
 }
 
 .projects-subtitle {
-  font-size: 1rem;
-  opacity: 0.55;
-  margin: 0;
-  max-width: 560px;
+  font-size: 0.95rem;
+  opacity: 0.5;
+  margin: 0 0 3rem;
 }
 
 .projects-section {
   margin-bottom: 4rem;
 }
 
-.projects-section-label {
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  opacity: 0.4;
-  margin: 0 0 0.35rem;
-}
-
-.projects-section-desc {
-  font-size: 0.85rem;
-  opacity: 0.45;
-  margin: 0 0 1.75rem;
-}
-
-/* ── Active project cards ─────────────────────────────────────────────── */
-
-.projects-active-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1.25rem;
-}
-
-.project-active-card {
-  position: relative;
-  border: 1px solid rgba(128,128,128,0.15);
-  border-radius: 10px;
-  overflow: hidden;
+/* Section label with crimson-rule left accent */
+.projects-section-rule {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 2.5rem;
 }
 
-.project-card-image img {
-  width: 100%;
-  height: 160px;
-  object-fit: cover;
+.projects-section-rule::before {
+  content: '';
   display: block;
+  height: 1px;
+  width: 1.5rem;
+  background: var(--teal);
+  flex-shrink: 0;
 }
 
-.project-card-body {
-  padding: 1.25rem 1.25rem 1.5rem;
+.projects-section-rule::after {
+  content: '';
   flex: 1;
+  height: 1px;
+  background: rgba(128,128,128,0.15);
 }
 
-.project-card-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-bottom: 0.6rem;
-}
-
-.project-tag {
+.projects-section-label {
   font-size: 0.7rem;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  padding: 0.2rem 0.55rem;
-  border-radius: 20px;
-  border: 1px solid rgba(128,128,128,0.25);
-  opacity: 0.65;
-}
-
-.project-card-title {
-  font-size: 1rem;
   font-weight: 600;
-  margin: 0 0 0.5rem;
-  line-height: 1.3;
-}
-
-.project-card-summary {
-  font-size: 0.85rem;
-  line-height: 1.6;
-  opacity: 0.6;
-  margin: 0;
-}
-
-.project-status-badge {
-  position: absolute;
-  top: 0.75rem;
-  right: 0.75rem;
-  font-size: 0.65rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
   text-transform: uppercase;
-  padding: 0.2rem 0.55rem;
-  border-radius: 20px;
-  background: rgba(34, 197, 94, 0.15);
-  color: rgb(34, 197, 94);
-  border: 1px solid rgba(34, 197, 94, 0.3);
+  letter-spacing: 0.12em;
+  color: var(--teal);
+  flex-shrink: 0;
 }
 
-/* ── Research theme entries ───────────────────────────────────────────── */
+/* Two-column row */
+.project-row {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 2rem;
+  padding: 2rem 0;
+  border-bottom: 1px solid rgba(128,128,128,0.1);
+}
 
-.projects-themes-list {
+.project-row:last-child {
+  border-bottom: none;
+}
+
+.project-row-left {
   display: flex;
   flex-direction: column;
-  gap: 0;
+  align-items: flex-end;
+  padding-top: 0.15rem;
+  gap: 0.5rem;
 }
 
-.project-theme {
-  padding: 2rem 0;
-  border-bottom: 1px solid rgba(128,128,128,0.12);
+.project-row-num {
+  font-family: 'Lora', Georgia, serif;
+  font-style: italic;
+  font-size: 2rem;
+  font-weight: 400;
+  color: var(--teal);
+  opacity: 0.3;
+  line-height: 1;
 }
 
-.project-theme:first-child {
+.project-active-tag {
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--coral);
+  border: 1px solid var(--coral-soft);
+  padding: 0.15rem 0.4rem;
+  border-radius: 2px;
+}
+
+.project-row-right {
   padding-top: 0;
 }
 
-.project-theme-header {
+/* Tags */
+.project-tags {
   display: flex;
-  gap: 1.5rem;
-  align-items: flex-start;
-  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.65rem;
 }
 
-.project-theme-image {
-  flex-shrink: 0;
-  width: 120px;
-}
-
-.project-theme-image img {
-  width: 120px;
-  height: 90px;
-  object-fit: cover;
-  border-radius: 6px;
-  display: block;
-}
-
-.project-theme-meta {
-  flex: 1;
-}
-
-.project-theme-title {
-  font-size: 1.1rem;
-  font-weight: 600;
-  margin: 0.4rem 0 0.5rem;
-  line-height: 1.3;
-}
-
-.project-theme-summary {
-  font-size: 0.87rem;
-  line-height: 1.65;
+.project-tag {
+  font-size: 0.68rem;
+  letter-spacing: 0.03em;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid rgba(128,128,128,0.2);
+  border-radius: 2px;
   opacity: 0.6;
-  margin: 0;
 }
 
-.project-theme-pubs {
+/* Title */
+.project-title {
+  font-family: 'Lora', Georgia, serif;
+  font-size: 1.2rem;
+  font-weight: 600;
+  font-style: italic;
+  margin: 0 0 0.6rem;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+
+/* Summary */
+.project-summary {
+  font-size: 0.9rem;
+  line-height: 1.7;
+  opacity: 0.62;
+  margin: 0 0 1.25rem;
+  max-width: 52ch;
+}
+
+/* Publication list — left border accent */
+.project-pubs {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  margin-left: 0;
+  border-left: 2px solid var(--teal-soft);
+  padding-left: 1rem;
+  gap: 0.25rem;
 }
 
-.project-pub-link {
+.project-pub-row {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
   gap: 1rem;
-  padding: 0.6rem 0.85rem;
-  border-radius: 6px;
-  background: rgba(128,128,128,0.05);
-  border: 1px solid rgba(128,128,128,0.1);
   text-decoration: none;
-  transition: background 0.15s;
+  padding: 0.2rem 0;
+  transition: color 0.15s;
 }
 
-.project-pub-link:hover {
-  background: rgba(128,128,128,0.1);
+.project-pub-row:hover .project-pub-title {
+  color: var(--teal);
 }
 
 .project-pub-title {
   font-size: 0.85rem;
   line-height: 1.4;
   flex: 1;
+  transition: color 0.15s;
 }
 
 .project-pub-meta {
-  font-size: 0.75rem;
+  font-size: 0.72rem;
+  color: var(--deep-purple);
   opacity: 0.4;
   white-space: nowrap;
   flex-shrink: 0;
 }
 
 @media (max-width: 600px) {
-  .projects-active-grid { grid-template-columns: 1fr; }
-  .project-theme-image { display: none; }
-  .project-pub-link { flex-direction: column; gap: 0.2rem; }
-  .project-pub-meta { white-space: normal; }
+  .project-row {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+  }
+  .project-row-left {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .project-row-num { font-size: 1.25rem; }
+}
+
+/* ── Meanwhile — magazine format ─────────────────────────────────────────── */
+
+/* Strip default page padding so slides go edge-to-edge */
+.mag-outer {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 68px); /* approx nav height */
+  overflow: hidden;
+}
+
+/* Top bar: title + view toggle */
+.mag-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 2rem;
+  border-bottom: 1px solid rgba(128,128,128,0.12);
+  flex-shrink: 0;
+  background: var(--bg);
+}
+
+.mag-page-title {
+  font-size: 1.1rem;
+  font-style: italic;
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.mag-view-toggle {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.mag-toggle-btn {
+  font-family: 'Lora', Georgia, serif;
+  font-size: 0.72rem;
+  padding: 0.25rem 0.65rem;
+  border: 1px solid rgba(128,128,128,0.25);
+  border-radius: 3px;
+  background: none;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: opacity 0.15s, border-color 0.15s;
+}
+
+.mag-toggle-btn.is-active {
+  opacity: 1;
+  border-color: var(--teal);
+  color: var(--teal);
+}
+
+/* Slide container — vertical scroll-snap */
+.mag-slides {
+  flex: 1;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Slide container — horizontal */
+.mag-slides.mag-horizontal {
+  overflow-y: hidden;
+  overflow-x: scroll;
+  scroll-snap-type: x mandatory;
+  display: flex;
+  flex-wrap: nowrap;
+}
+
+/* Individual slide */
+.mag-slide {
+  position: relative;
+  height: 100%;
+  scroll-snap-align: start;
+  flex-shrink: 0;
+  overflow: hidden;
+  background: var(--deep-purple);
+}
+
+.mag-slides.mag-horizontal .mag-slide {
+  width: 100vw;
+}
+
+/* Full-bleed image */
+.mag-full-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* Overlay for image captions */
+.mag-slide-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 2rem 2.5rem;
+  background: linear-gradient(transparent, rgba(0,0,0,0.6));
+}
+
+.mag-caption {
+  font-size: 0.88rem;
+  color: rgba(255,255,255,0.85);
+  margin: 0;
+  font-style: italic;
+}
+
+/* Text slide */
+.mag-text-fill {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 3rem 10%;
+}
+
+.mag-text-body {
+  font-size: clamp(1.25rem, 2.5vw, 2rem);
+  line-height: 1.55;
+  color: rgba(255,255,255,0.92);
+  margin: 0 0 1rem;
+  max-width: 28ch;
+}
+
+.mag-attribution {
+  font-size: 0.85rem;
+  color: rgba(255,255,255,0.45);
+  font-style: italic;
+}
+
+/* Travel slide */
+.mag-travel-content {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 2.5rem;
+  background: linear-gradient(transparent, rgba(60,26,91,0.85));
+}
+
+.mag-travel-label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--teal);
+  display: block;
+  margin-bottom: 0.4rem;
+}
+
+.mag-travel-location {
+  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  font-style: italic;
+  font-weight: 600;
+  color: #fff;
+  margin: 0 0 0.3rem;
+}
+
+.mag-travel-date {
+  font-size: 0.82rem;
+  color: rgba(255,255,255,0.55);
+  display: block;
+  margin-bottom: 0.6rem;
+}
+
+.mag-travel-text {
+  font-size: 0.9rem;
+  color: rgba(255,255,255,0.75);
+  margin: 0;
+  max-width: 40ch;
+}
+
+/* Link slide */
+.mag-link-fill {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+}
+
+.mag-link-img {
+  width: 100%;
+  height: 55%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.mag-link-body {
+  flex: 1;
+  padding: 2rem 10%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.mag-source-label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--teal);
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.mag-link-title {
+  font-size: clamp(1.2rem, 2.5vw, 1.8rem);
+  font-weight: 600;
+  font-style: italic;
+  margin: 0 0 0.75rem;
+  max-width: 30ch;
+}
+
+.mag-link-desc {
+  font-size: 0.9rem;
+  opacity: 0.6;
+  margin: 0 0 1.25rem;
+  max-width: 44ch;
+}
+
+.mag-link-cta {
+  font-size: 0.8rem;
+  color: var(--teal);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+/* Floating next-slide arrow */
+.mag-arrow-btn {
+  position: absolute;
+  bottom: 1.75rem;
+  right: 2rem;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.15);
+  border: 1px solid rgba(255,255,255,0.3);
+  color: #fff;
+  font-size: 1.1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+  backdrop-filter: blur(4px);
+  z-index: 10;
+}
+
+.mag-arrow-btn:hover {
+  background: rgba(255,255,255,0.28);
+}
+
+/* For light slides (link/text on cream), use dark arrow */
+.slide-type-link .mag-arrow-btn {
+  background: rgba(0,0,0,0.08);
+  border-color: rgba(0,0,0,0.15);
+  color: var(--text);
+}
+
+.slide-type-link .mag-arrow-btn:hover {
+  background: rgba(0,0,0,0.15);
 }

--- a/data/meanwhile.yaml
+++ b/data/meanwhile.yaml
@@ -1,43 +1,32 @@
-# Meanwhile page content
-# Each item becomes a cell in the editorial grid.
+# Meanwhile — magazine content
 #
-# Types:  text | image | link | video | project
-# Sizes:  small (1×1) | medium (2×1) | large (2×2) | hero (3×2)
+# Types:
+#   text    — colored full-page text block
+#   image   — full-bleed photo
+#   travel  — full-bleed photo with location/date overlay panel
+#   link    — article or link card
 #
-# Text cells accept a `color` field for the background (any CSS color):
-#   color: "#2a3a4f"   dark blue-grey
-#   color: "#3b2a2a"   dark wine
-#   color: "#1e2e1e"   dark forest
-#   color: "#2e2a1a"   dark ochre
-#
-# For images, place files in static/media/meanwhile/ and use /media/meanwhile/filename.jpg
-# For videos, use the embed URL: https://www.youtube.com/embed/VIDEO_ID
+# For images: place files in static/media/meanwhile/ and reference as /media/meanwhile/filename.jpg
+# For travel entries, add: location, date (string), text (optional), src (optional photo)
 
 - type: text
   text: "Outside of research, I like to run and swim. I also like crafts like making plushies :))"
-  color: "#CB2957"
-  size: small
-
+  color: "#4B1A6B"
 
 - type: image
   src: /media/meanwhile/mooncake_solo.jpg
-  alt: "green frog plush on couch"
-  caption: "Mooncake - Frog plushie made for the CoEx lab"
-  size: large
-
+  alt: "green frog plush"
+  caption: "Mooncake — frog plushie made for the CoEx lab"
 
 - type: image
   src: /media/meanwhile/couples_frog.jpg
   alt: "green and pink frog plush set"
   caption: "frog set :)"
-  size: large
 
-
-
-# To add an image: upload to static/media/meanwhile/ then uncomment:
-# - type: image
+# To add a travel entry:
+# - type: travel
 #   src: /media/meanwhile/your-photo.jpg
 #   alt: "Description"
-#   caption: "Optional caption"
-#   size: large
-
+#   location: "Tokyo, Japan"
+#   date: "March 2025"
+#   text: "Optional short caption or reflection."

--- a/layouts/meanwhile/list.html
+++ b/layouts/meanwhile/list.html
@@ -1,75 +1,99 @@
 {{ define "main" }}
-<section class="meanwhile-page">
+<div class="mag-outer">
 
-  <div class="meanwhile-header">
-    <h1 class="meanwhile-title">{{ .Title }}</h1>
-    {{ with .Description }}<p class="meanwhile-subtitle">{{ . }}</p>{{ end }}
+  <div class="mag-topbar">
+    <h1 class="mag-page-title">{{ .Title }}</h1>
+    <div class="mag-view-toggle">
+      <button class="mag-toggle-btn is-active" id="btn-vertical" onclick="setMagView('vertical')">↕ Scroll</button>
+      <button class="mag-toggle-btn" id="btn-horizontal" onclick="setMagView('horizontal')">→ Swipe</button>
+    </div>
   </div>
 
-  <div class="meanwhile-grid">
-    {{ range site.Data.meanwhile }}
+  <div class="mag-slides mag-vertical" id="mag-slides">
+    {{ range $i, $item := site.Data.meanwhile }}
+    <div class="mag-slide slide-type-{{ .type | default "text" }}" id="mag-slide-{{ $i }}">
 
-    {{/* ── text ── */}}
-    {{ if eq .type "text" }}
-    <div class="meanwhile-cell type-text size-{{ .size | default "small" }}"
-         {{ with .color }}style="background-color: {{ . }};"{{ end }}>
-      <p class="cell-text-body">{{ .text }}</p>
-      {{ with .attribution }}<span class="cell-attribution">— {{ . }}</span>{{ end }}
-    </div>
-
-    {{/* ── image ── */}}
-    {{ else if eq .type "image" }}
-    {{ if .src }}
-    <div class="meanwhile-cell type-image size-{{ .size | default "large" }}">
-      <img src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">
-      {{ with .caption }}<div class="cell-caption">{{ . }}</div>{{ end }}
-    </div>
-    {{ end }}
-
-    {{/* ── link ── */}}
-    {{ else if eq .type "link" }}
-    <a class="meanwhile-cell type-link size-{{ .size | default "medium" }}"
-       href="{{ .url }}" target="_blank" rel="noopener noreferrer">
-      {{ with .image }}<img src="{{ . }}" alt="" loading="lazy">{{ end }}
-      <div class="cell-link-body">
-        {{ with .source }}<span class="cell-source">{{ . }}</span>{{ end }}
-        <h3>{{ .title }}</h3>
-        {{ with .description }}<p>{{ . }}</p>{{ end }}
+      {{/* ── full-bleed image ── */}}
+      {{ if eq .type "image" }}
+      {{ if .src }}
+      <img class="mag-full-img" src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">
+      <div class="mag-slide-overlay">
+        {{ with .caption }}<p class="mag-caption">{{ . }}</p>{{ end }}
       </div>
-      <span class="cell-arrow">↗</span>
-    </a>
+      {{ end }}
 
-    {{/* ── video ── */}}
-    {{ else if eq .type "video" }}
-    <div class="meanwhile-cell type-video size-{{ .size | default "medium" }}">
-      <div class="cell-video-wrapper">
-        <iframe src="{{ .embed_url }}"
-                title="{{ .title | default "Video" }}"
-                frameborder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowfullscreen
-                loading="lazy"></iframe>
+      {{/* ── travel: full-bleed image + text panel ── */}}
+      {{ else if eq .type "travel" }}
+      {{ if .src }}
+      <img class="mag-full-img" src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">
+      {{ end }}
+      <div class="mag-travel-content">
+        <span class="mag-travel-label">Travel</span>
+        {{ with .location }}<h2 class="mag-travel-location">{{ . }}</h2>{{ end }}
+        {{ with .date }}<span class="mag-travel-date">{{ . }}</span>{{ end }}
+        {{ with .text }}<p class="mag-travel-text">{{ . }}</p>{{ end }}
       </div>
-      {{ with .title }}<div class="cell-caption">{{ . }}</div>{{ end }}
+
+      {{/* ── text block ── */}}
+      {{ else if eq .type "text" }}
+      <div class="mag-text-fill" {{ with .color }}style="background:{{ . }}"{{ end }}>
+        <p class="mag-text-body">{{ .text }}</p>
+        {{ with .attribution }}<span class="mag-attribution">— {{ . }}</span>{{ end }}
+      </div>
+
+      {{/* ── link / article ── */}}
+      {{ else if eq .type "link" }}
+      <div class="mag-link-fill">
+        {{ if .image }}<img class="mag-link-img" src="{{ .image }}" alt="">{{ end }}
+        <div class="mag-link-body">
+          {{ with .source }}<span class="mag-source-label">{{ . }}</span>{{ end }}
+          <h2 class="mag-link-title">{{ .title }}</h2>
+          {{ with .description }}<p class="mag-link-desc">{{ . }}</p>{{ end }}
+          <a class="mag-link-cta" href="{{ .url }}" target="_blank" rel="noopener">Read ↗</a>
+        </div>
+      </div>
+
+      {{ end }}
+
+      {{/* floating advance arrow */}}
+      {{ $total := len site.Data.meanwhile }}
+      {{ $next := add $i 1 }}
+      {{ if lt $next $total }}
+      <button class="mag-arrow-btn" onclick="magGoTo({{ $next }})" aria-label="Next">
+        <span class="mag-arrow-icon">↓</span>
+      </button>
+      {{ end }}
+
     </div>
-
-    {{/* ── project ── */}}
-    {{ else if eq .type "project" }}
-    <a class="meanwhile-cell type-project size-{{ .size | default "medium" }}"
-       href="{{ .url }}"
-       {{ if strings.HasPrefix .url "http" }}target="_blank" rel="noopener noreferrer"{{ end }}>
-      {{ with .image }}<img src="{{ . }}" alt="{{ $.title | default "" }}" loading="lazy">{{ end }}
-      <div class="cell-project-body">
-        {{ with .tag }}<span class="cell-tag">{{ . }}</span>{{ end }}
-        <h3>{{ .title }}</h3>
-        {{ with .description }}<p>{{ . }}</p>{{ end }}
-      </div>
-      <span class="cell-arrow">→</span>
-    </a>
-
-    {{ end }}
     {{ end }}
   </div>
 
-</section>
+</div>
+
+<script>
+(function () {
+  window.magGoTo = function (index) {
+    var slide = document.getElementById('mag-slide-' + index);
+    if (!slide) return;
+    var container = document.getElementById('mag-slides');
+    var isH = container.classList.contains('mag-horizontal');
+    slide.scrollIntoView({
+      behavior: 'smooth',
+      block: isH ? 'nearest' : 'start',
+      inline: isH ? 'start' : 'nearest'
+    });
+  };
+
+  window.setMagView = function (mode) {
+    var container = document.getElementById('mag-slides');
+    container.className = 'mag-slides mag-' + mode;
+    document.getElementById('btn-vertical').classList.toggle('is-active', mode === 'vertical');
+    document.getElementById('btn-horizontal').classList.toggle('is-active', mode === 'horizontal');
+    document.querySelectorAll('.mag-arrow-icon').forEach(function (el) {
+      el.textContent = mode === 'vertical' ? '↓' : '→';
+    });
+    magGoTo(0);
+  };
+})();
+</script>
 {{ end }}

--- a/layouts/project/list.html
+++ b/layouts/project/list.html
@@ -1,72 +1,64 @@
 {{ define "main" }}
 <section class="projects-page">
 
-  <div class="projects-header">
-    <h1 class="projects-title">{{ .Title }}</h1>
-    {{ with .Description }}<p class="projects-subtitle">{{ . }}</p>{{ end }}
-  </div>
+  <h1 class="projects-title">{{ .Title }}</h1>
+  {{ with .Description }}<p class="projects-subtitle">{{ . }}</p>{{ end }}
 
-  {{/* ── Current Work ───────────────────────────────────────────────────── */}}
+  {{/* ── Current Work ── */}}
   {{ $active := where .Pages "Params.status" "active" }}
   {{ if $active }}
   <div class="projects-section">
-    <h2 class="projects-section-label">Current Work</h2>
-    <p class="projects-section-desc">In progress — no publication yet.</p>
-    <div class="projects-active-grid">
-      {{ range $active.ByDate.Reverse }}
-      <div class="project-active-card">
-        {{ with .Resources.GetMatch "featured*" }}
-        <div class="project-card-image">
-          <img src="{{ .RelPermalink }}" alt="{{ $.Title }}" loading="lazy">
+    <div class="projects-section-rule">
+      <span class="projects-section-label">Current Work</span>
+    </div>
+    {{ range $i, $p := $active.ByDate.Reverse }}
+    <div class="project-row">
+      <div class="project-row-left">
+        <span class="project-row-num">{{ printf "%02d" (add $i 1) }}</span>
+        <span class="project-active-tag">Active</span>
+      </div>
+      <div class="project-row-right">
+        {{ if .Params.tags }}
+        <div class="project-tags">
+          {{ range .Params.tags }}<span class="project-tag">{{ . }}</span>{{ end }}
         </div>
         {{ end }}
-        <div class="project-card-body">
-          <div class="project-card-tags">
-            {{ range .Params.tags }}<span class="project-tag">{{ . }}</span>{{ end }}
-          </div>
-          <h3 class="project-card-title">{{ .Title }}</h3>
-          <p class="project-card-summary">{{ .Params.summary }}</p>
-        </div>
-        <span class="project-status-badge">Active</span>
+        <h3 class="project-title">{{ .Title }}</h3>
+        {{ with .Params.summary }}<p class="project-summary">{{ . }}</p>{{ end }}
       </div>
-      {{ end }}
     </div>
+    {{ end }}
   </div>
   {{ end }}
 
-  {{/* ── Research Themes ─────────────────────────────────────────────────── */}}
+  {{/* ── Research Themes ── */}}
   {{ $themes := where .Pages "Params.status" "theme" }}
   {{ if $themes }}
   <div class="projects-section">
-    <h2 class="projects-section-label">Research Themes</h2>
-    <p class="projects-section-desc">Lines of inquiry spanning multiple publications.</p>
-    <div class="projects-themes-list">
-      {{ range $themes.ByDate.Reverse }}
-      {{ $theme := . }}
-      <div class="project-theme">
-        <div class="project-theme-header">
-          {{ with .Resources.GetMatch "featured*" }}
-          <div class="project-theme-image">
-            <img src="{{ .RelPermalink }}" alt="{{ $theme.Title }}" loading="lazy">
-          </div>
-          {{ end }}
-          <div class="project-theme-meta">
-            <div class="project-card-tags">
-              {{ range .Params.tags }}<span class="project-tag">{{ . }}</span>{{ end }}
-            </div>
-            <h3 class="project-theme-title">{{ .Title }}</h3>
-            <p class="project-theme-summary">{{ .Params.summary }}</p>
-          </div>
+    <div class="projects-section-rule">
+      <span class="projects-section-label">Research Themes</span>
+    </div>
+    {{ range $i, $p := $themes.ByDate.Reverse }}
+    <div class="project-row">
+      <div class="project-row-left">
+        <span class="project-row-num">{{ printf "%02d" (add $i 1) }}</span>
+      </div>
+      <div class="project-row-right">
+        {{ if .Params.tags }}
+        <div class="project-tags">
+          {{ range .Params.tags }}<span class="project-tag">{{ . }}</span>{{ end }}
         </div>
+        {{ end }}
+        <h3 class="project-title">{{ .Title }}</h3>
+        {{ with .Params.summary }}<p class="project-summary">{{ . }}</p>{{ end }}
 
-        {{/* Linked publications */}}
         {{ with .Params.related_pubs }}
-        <div class="project-theme-pubs">
+        <div class="project-pubs">
           {{ range . }}
           {{ $slug := . }}
           {{ $pub := index (where site.RegularPages "File.Dir" (printf "publication/%s/" $slug)) 0 }}
           {{ with $pub }}
-          <a class="project-pub-link" href="{{ .RelPermalink }}">
+          <a class="project-pub-row" href="{{ .RelPermalink }}">
             <span class="project-pub-title">{{ .Title }}</span>
             <span class="project-pub-meta">
               {{ with .Params.publication_types }}
@@ -82,8 +74,8 @@
         {{ end }}
 
       </div>
-      {{ end }}
     </div>
+    {{ end }}
   </div>
   {{ end }}
 


### PR DESCRIPTION
## Summary

### Color palette (cream / teal / coral / deep purple)
- Page background → cream `#F2EDE4`
- Primary accent → teal `#6DCBD5` (replaces crimson — much more readable)
- Secondary accent → coral `#E05A4E` (used for Active badge, coral buttons)
- Dark accent → deep purple `#3C1A5B` (section headings, year labels)
- **Publication type badges** now have colored text + colored border — Conference (teal), Journal (purple), Workshop (coral), Preprint (muted) — all fully readable on the cream background

### Projects page — two-column editorial
- Removes card/grid boxes entirely
- Left column: large faded italic teal number (`01`, `02`, …)
- Right column: tag chips, italic Lora title, summary paragraph, linked pubs with teal left-border rule
- Active projects show a coral "Active" tag beside the number

### Meanwhile page — magazine format
- Full-viewport slides with scroll-snap
- Toggle at top-right to switch between **↕ Scroll** (vertical snap) and **→ Swipe** (horizontal carousel)
- Slide types: `image` (full-bleed photo + caption), `travel` (photo + location/date panel), `text` (colored full-page), `link` (split image + body)
- Floating circular arrow button advances to the next slide
- `data/meanwhile.yaml` now documents the `travel` type with location/date/text fields

## Test plan
- [ ] Publications page: check Conference/Journal/Workshop/Preprint badges are readable on cream background
- [ ] Projects page: verify two-column layout with numbered rows and pub links
- [ ] Meanwhile page: verify slides fill viewport, toggle switches between scroll/swipe modes, arrow button works
- [ ] Mobile: project rows collapse to single column, meanwhile slides still full-screen

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_