### PR TITLE
Fix preprint badge + Meanwhile collage slides + image size guide

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -334,9 +334,9 @@ body {
 }
 
 .badge-preprint {
-  color: var(--text);
-  opacity: 0.45;
-  border-color: rgba(128,128,128,0.25);
+  color: var(--teal);
+  border-color: var(--teal-soft);
+  border-style: dashed;
 }
 
 .badge-other {
@@ -957,4 +957,63 @@ body {
 
 .slide-type-link .mag-arrow-btn:hover {
   background: rgba(0,0,0,0.15);
+}
+
+/* ── Collage slide ───────────────────────────────────────────────────────── */
+
+.mag-collage-fill {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(var(--collage-cols, 2), 1fr);
+  gap: 3px;
+}
+
+.mag-collage-item {
+  position: relative;
+  overflow: hidden;
+  background: var(--deep-purple);
+  min-height: 0;
+}
+
+.mag-collage-item.span-2 {
+  grid-column: span 2;
+}
+
+.mag-collage-item.span-3 {
+  grid-column: span 3;
+}
+
+.mag-collage-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.mag-collage-item.is-text {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem 2rem;
+}
+
+.mag-collage-text {
+  font-size: clamp(0.9rem, 1.5vw, 1.2rem);
+  color: rgba(255,255,255,0.9);
+  margin: 0;
+  text-align: center;
+  line-height: 1.6;
+}
+
+.mag-collage-caption {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0.5rem 0.75rem;
+  background: linear-gradient(transparent, rgba(0,0,0,0.55));
+  font-size: 0.78rem;
+  color: rgba(255,255,255,0.82);
+  font-style: italic;
 }

--- a/data/meanwhile.yaml
+++ b/data/meanwhile.yaml
@@ -1,32 +1,37 @@
 # Meanwhile — magazine content
 #
-# Types:
-#   text    — colored full-page text block
-#   image   — full-bleed photo
-#   travel  — full-bleed photo with location/date overlay panel
-#   link    — article or link card
+# Slide types:
+#   image    — full-page photo with optional caption
+#   travel   — full-page photo + location / date overlay
+#   text     — full-page colored text block
+#   link     — article or link with optional image
+#   collage  — multiple images/text in one viewport (see IMAGE_GUIDE.txt)
 #
-# For images: place files in static/media/meanwhile/ and reference as /media/meanwhile/filename.jpg
-# For travel entries, add: location, date (string), text (optional), src (optional photo)
+# For images: place files in static/media/meanwhile/
+# Reference as: /media/meanwhile/filename.jpg
+#
+# See static/media/meanwhile/IMAGE_GUIDE.txt for recommended dimensions.
 
 - type: text
   text: "Outside of research, I like to run and swim. I also like crafts like making plushies :))"
   color: "#4B1A6B"
 
-- type: image
-  src: /media/meanwhile/mooncake_solo.jpg
-  alt: "green frog plush"
-  caption: "Mooncake — frog plushie made for the CoEx lab"
+- type: collage
+  columns: 2
+  items:
+    - src: /media/meanwhile/mooncake_solo.jpg
+      alt: "green frog plush"
+      caption: "Mooncake — frog plushie made for the CoEx lab"
+      span: 1
+    - src: /media/meanwhile/couples_frog.jpg
+      alt: "green and pink frog plush set"
+      caption: "frog set :)"
+      span: 1
 
-- type: image
-  src: /media/meanwhile/couples_frog.jpg
-  alt: "green and pink frog plush set"
-  caption: "frog set :)"
-
-# To add a travel entry:
+# To add a full-page travel entry:
 # - type: travel
 #   src: /media/meanwhile/your-photo.jpg
 #   alt: "Description"
 #   location: "Tokyo, Japan"
 #   date: "March 2025"
-#   text: "Optional short caption or reflection."
+#   text: "Optional short caption."

--- a/layouts/meanwhile/list.html
+++ b/layouts/meanwhile/list.html
@@ -53,6 +53,23 @@
         </div>
       </div>
 
+      {{/* ── collage: multiple items in one slide ── */}}
+      {{ else if eq .type "collage" }}
+      <div class="mag-collage-fill"
+           {{ with .columns }}style="--collage-cols:{{ . }}"{{ end }}>
+        {{ range .items }}
+        <div class="mag-collage-item{{ if .span }} span-{{ .span }}{{ end }}{{ if eq .type "text" }} is-text{{ end }}"
+             {{ if and (eq .type "text") .color }}style="background:{{ .color }}"{{ end }}>
+          {{ if .src }}
+          <img src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">
+          {{ with .caption }}<div class="mag-collage-caption">{{ . }}</div>{{ end }}
+          {{ else if eq .type "text" }}
+          <p class="mag-collage-text">{{ .text }}</p>
+          {{ end }}
+        </div>
+        {{ end }}
+      </div>
+
       {{ end }}
 
       {{/* floating advance arrow */}}

--- a/static/media/meanwhile/IMAGE_GUIDE.txt
+++ b/static/media/meanwhile/IMAGE_GUIDE.txt
@@ -1,0 +1,96 @@
+Meanwhile — Image & Slide Size Guide
+=====================================
+
+FULL-PAGE SLIDES
+----------------
+Types: image, travel, text, link
+
+Each slide fills the entire viewport (100% screen height × 100% screen width).
+Use these for a single strong photo or a full-color text moment.
+
+Recommended image dimensions:
+  • Landscape:  1920 × 1080 px  (16:9)  ← ideal for most screens
+  • Portrait:   1200 × 1600 px  (3:4)   works but crops on wide screens
+  • Minimum width: 1440 px to avoid blurriness on high-res displays
+  • File size: keep under 800 KB (JPEG quality 80–85)
+
+YAML example:
+  - type: image
+    src: /media/meanwhile/tokyo-night.jpg
+    alt: "Description for screen readers"
+    caption: "Optional caption shown at bottom"
+
+  - type: travel
+    src: /media/meanwhile/kyoto-temple.jpg
+    location: "Kyoto, Japan"
+    date: "March 2025"
+    text: "Optional short reflection."
+
+
+COLLAGE SLIDES
+--------------
+Type: collage
+
+Multiple items arranged in a grid, still filling the full viewport.
+Mix photos, text panels, or any combination.
+
+Default grid: 2 columns. Add `columns: 3` for three columns.
+
+Item span (how many columns an item takes):
+  • span: 1  →  occupies 1 column  (default)
+  • span: 2  →  occupies 2 columns (wide/banner)
+  • span: 3  →  full width in a 3-column grid
+
+Recommended image sizes per item (2-column grid):
+  • span 1:  800 × 600 px minimum  (4:3 aspect)
+  • span 2:  1600 × 600 px minimum (wide banner)
+
+Recommended image sizes per item (3-column grid):
+  • span 1:  600 × 500 px minimum
+  • span 2:  1200 × 500 px minimum
+  • span 3:  1800 × 500 px minimum
+
+Recommended max items per collage: 4–6
+(more than 6 gets crowded on phones)
+
+YAML example (2-column, 4 items):
+  - type: collage
+    columns: 2          # optional, default is 2
+    items:
+      - src: /media/meanwhile/photo-a.jpg
+        alt: "..."
+        caption: "optional"
+        span: 2         # this photo spans both columns
+      - src: /media/meanwhile/photo-b.jpg
+        alt: "..."
+      - src: /media/meanwhile/photo-c.jpg
+        alt: "..."
+      - type: text
+        text: "A little note about this trip."
+        color: "#4B1A6B"   # any CSS color for the background
+
+YAML example (3-column):
+  - type: collage
+    columns: 3
+    items:
+      - src: /media/meanwhile/photo-1.jpg
+        span: 2
+      - src: /media/meanwhile/photo-2.jpg
+        span: 1
+      - src: /media/meanwhile/photo-3.jpg
+        span: 1
+      - src: /media/meanwhile/photo-4.jpg
+        span: 1
+      - src: /media/meanwhile/photo-5.jpg
+        span: 1
+
+
+GENERAL TIPS
+------------
+• Format: JPEG for photos (.jpg), PNG only if you need transparency
+• Name files clearly: tokyo-2025-shibuya.jpg — not IMG_5342.jpg
+• Place all files in: static/media/meanwhile/
+• Reference in YAML as: /media/meanwhile/filename.jpg
+• The scroll/swipe toggle at the top of the page switches between
+  vertical scroll-snap (default) and horizontal carousel — both
+  layouts use the same full-page and collage slides.


### PR DESCRIPTION
## Summary

### Preprint badge fix
- Was: near-invisible dark text at low opacity on cream background
- Now: teal color with dashed border — readable and visually distinct from Conference (solid teal border)

### Meanwhile: collage slide type
New `type: collage` lets you mix multiple images and text panels into one full-viewport slide.

```yaml
- type: collage
  columns: 2          # 2 or 3 columns (default: 2)
  items:
    - src: /media/meanwhile/photo-a.jpg
      alt: "..."
      caption: "optional"
      span: 2         # spans both columns (banner)
    - src: /media/meanwhile/photo-b.jpg
    - type: text
      text: "A short note."
      color: "#4B1A6B"
```

Each item supports:
- `span: 1|2|3` — how many columns it occupies
- `type: text` with `color:` — a colored text panel instead of a photo
- `caption:` — small caption overlaid at the bottom of a photo

The two frog photos are now shown as a 2-column collage slide instead of two separate full-page slides.

### Image size guide
`static/media/meanwhile/IMAGE_GUIDE.txt` — an internal reference file (not published to the site) covering:
- Full-page image dimensions (1920×1080 recommended)
- Collage item dimensions by span and column count
- File format, naming, and path conventions

## Test plan
- [ ] Publications page: Preprint badge is teal with dashed border, visually distinct from Conference
- [ ] Meanwhile: frog photos appear side-by-side in a collage slide
- [ ] Meanwhile: toggle between vertical/horizontal still works with collage slides
- [ ] Add a `type: collage` entry to YAML to verify custom columns and spans render correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_