### PR TITLE
Venue short tags, accordion projects, sneaker removed

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -575,7 +575,21 @@ body {
   margin: 0;
 }
 
-/* ── Projects page — two-column editorial ────────────────────────────────── */
+/* ── Venue short tag ─────────────────────────────────────────────────────── */
+
+.venue-short-tag {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.15rem 0.5rem;
+  border-radius: 2px;
+  background: var(--teal-subtle);
+  color: var(--deep-purple);
+  flex-shrink: 0;
+}
+
+/* ── Projects page — accordion layout ───────────────────────────────────── */
 
 .projects-page {
   max-width: 860px;
@@ -606,7 +620,7 @@ body {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  margin-bottom: 2.5rem;
+  margin-bottom: 1.5rem;
 }
 
 .projects-section-rule::before {
@@ -634,35 +648,68 @@ body {
   flex-shrink: 0;
 }
 
-/* Two-column row */
-.project-row {
-  display: grid;
-  grid-template-columns: 64px 1fr;
-  gap: 2rem;
-  padding: 2rem 0;
+/* ── Accordion ───────────────────────────────────────────────────────────── */
+
+.project-accordion {
   border-bottom: 1px solid rgba(128,128,128,0.1);
 }
 
-.project-row:last-child {
-  border-bottom: none;
+.project-accordion:first-of-type {
+  border-top: 1px solid rgba(128,128,128,0.1);
 }
 
-.project-row-left {
+.project-accordion-trigger {
+  width: 100%;
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  padding-top: 0.15rem;
-  gap: 0.5rem;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.1rem 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: opacity 0.15s;
 }
 
-.project-row-num {
+.project-accordion-trigger:hover {
+  opacity: 0.75;
+}
+
+.project-accordion-num {
   font-family: 'Lora', Georgia, serif;
   font-style: italic;
-  font-size: 2rem;
+  font-size: 1.1rem;
   font-weight: 400;
   color: var(--teal);
-  opacity: 0.3;
-  line-height: 1;
+  opacity: 0.45;
+  flex-shrink: 0;
+  width: 2rem;
+  text-align: right;
+}
+
+.project-accordion-title {
+  font-family: 'Lora', Georgia, serif;
+  font-size: 1.05rem;
+  font-weight: 600;
+  font-style: italic;
+  flex: 1;
+  line-height: 1.3;
+}
+
+.project-accordion-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  flex-shrink: 0;
+}
+
+.project-tag {
+  font-size: 0.65rem;
+  letter-spacing: 0.03em;
+  padding: 0.1rem 0.4rem;
+  border: 1px solid rgba(128,128,128,0.2);
+  border-radius: 2px;
+  opacity: 0.55;
 }
 
 .project-active-tag {
@@ -672,43 +719,36 @@ body {
   letter-spacing: 0.1em;
   color: var(--coral);
   border: 1px solid var(--coral-soft);
-  padding: 0.15rem 0.4rem;
+  padding: 0.1rem 0.4rem;
   border-radius: 2px;
+  flex-shrink: 0;
 }
 
-.project-row-right {
-  padding-top: 0;
+.project-accordion-arrow {
+  font-size: 0.85rem;
+  opacity: 0.35;
+  flex-shrink: 0;
+  transition: transform 0.25s ease, opacity 0.2s;
 }
 
-/* Tags */
-.project-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-  margin-bottom: 0.65rem;
+.project-accordion.is-open .project-accordion-arrow {
+  transform: rotate(180deg);
+  opacity: 0.7;
 }
 
-.project-tag {
-  font-size: 0.68rem;
-  letter-spacing: 0.03em;
-  padding: 0.15rem 0.5rem;
-  border: 1px solid rgba(128,128,128,0.2);
-  border-radius: 2px;
-  opacity: 0.6;
+/* Accordion body — hidden by default, slides open */
+.project-accordion-body {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.35s ease, padding 0.25s ease;
+  padding: 0 0 0 3rem;
 }
 
-/* Title */
-.project-title {
-  font-family: 'Lora', Georgia, serif;
-  font-size: 1.2rem;
-  font-weight: 600;
-  font-style: italic;
-  margin: 0 0 0.6rem;
-  line-height: 1.3;
-  letter-spacing: -0.01em;
+.project-accordion.is-open .project-accordion-body {
+  max-height: 600px;
+  padding: 0 0 1.5rem 3rem;
 }
 
-/* Summary */
 .project-summary {
   font-size: 0.9rem;
   line-height: 1.7;
@@ -717,7 +757,7 @@ body {
   max-width: 52ch;
 }
 
-/* Publication list — left border accent */
+/* Publication list inside accordion */
 .project-pubs {
   display: flex;
   flex-direction: column;
@@ -733,7 +773,6 @@ body {
   gap: 1rem;
   text-decoration: none;
   padding: 0.2rem 0;
-  transition: color 0.15s;
 }
 
 .project-pub-row:hover .project-pub-title {
@@ -756,16 +795,12 @@ body {
 }
 
 @media (max-width: 600px) {
-  .project-row {
-    grid-template-columns: 1fr;
-    gap: 0.5rem;
-  }
-  .project-row-left {
-    flex-direction: row;
-    align-items: center;
-    gap: 0.75rem;
-  }
-  .project-row-num { font-size: 1.25rem; }
+  .project-accordion-tags { display: none; }
+  .project-accordion-title { font-size: 0.95rem; }
+  .project-accordion-body { padding-left: 1rem; }
+  .project-accordion.is-open .project-accordion-body { padding-left: 1rem; }
+  .project-pub-row { flex-direction: column; gap: 0.15rem; }
+  .project-pub-meta { white-space: normal; }
 }
 
 /* ── Meanwhile — magazine format ─────────────────────────────────────────── */

--- a/content/publication/cazacu-2026-actualizing/index.md
+++ b/content/publication/cazacu-2026-actualizing/index.md
@@ -14,5 +14,6 @@ publishDate: '2026-01-01'
 publication_types:
 - chapter
 publication: '*ACM FAccT CRAFT 2026*'
+venue_short: 'FAccT'
 featured: false
 ---

--- a/content/publication/choong-2026-towards/index.md
+++ b/content/publication/choong-2026-towards/index.md
@@ -14,5 +14,6 @@ publishDate: '2026-01-01'
 publication_types:
 - manuscript
 publication: '*arXiv preprint arXiv:2605.07986*'
+venue_short: 'arXiv'
 featured: false
 ---

--- a/content/publication/han-2025-poet/index.md
+++ b/content/publication/han-2025-poet/index.md
@@ -12,5 +12,6 @@ publishDate: '2025-01-01'
 publication_types:
 - paper-conference
 publication: '*UIST 2025*'
+venue_short: 'UIST'
 featured: false
 ---

--- a/content/publication/jhaver-2023-personalizing/index.md
+++ b/content/publication/jhaver-2023-personalizing/index.md
@@ -12,6 +12,7 @@ publishDate: '2023-01-01'
 publication_types:
 - paper-conference
 publication: '*Proceedings of the ACM on Human-Computer Interaction 7 (CSCW2), 1-33*'
+venue_short: 'CSCW'
 featured: false
 url_pdf: https://dl.acm.org/doi/abs/10.1145/3610080
 url_video: ''

--- a/content/publication/peng-2025-exploring/index.md
+++ b/content/publication/peng-2025-exploring/index.md
@@ -15,5 +15,6 @@ publishDate: '2025-01-01'
 publication_types:
 - manuscript
 publication: '*arXiv preprint arXiv:2509.24167*'
+venue_short: 'arXiv'
 featured: false
 ---

--- a/content/publication/qian-2023-cleaning/index.md
+++ b/content/publication/qian-2023-cleaning/index.md
@@ -9,6 +9,7 @@ publishDate: '2023-01-01'
 publication_types:
 - manuscript
 publication: '*arXiv preprint arXiv:2309.06688*'
+venue_short: 'arXiv'
 featured: false
 url_pdf: https://arxiv.org/abs/2309.06688
 url_video: ''

--- a/content/publication/qian-2025-aura/index.md
+++ b/content/publication/qian-2025-aura/index.md
@@ -12,6 +12,7 @@ publishDate: '2025-01-01'
 publication_types:
 - paper-conference
 publication: '*Proceedings of the ACM on Human-Computer Interaction 9 (2), 1-45*'
+venue_short: 'CSCW'
 featured: false
 url_pdf: 'https://dl.acm.org/doi/abs/10.1145/3710931'
 url_video: ''

--- a/content/publication/qian-2025-effective/index.md
+++ b/content/publication/qian-2025-effective/index.md
@@ -10,5 +10,6 @@ publishDate: '2025-01-01'
 publication_types:
 - article-journal
 publication: '*Interactions 32 (4), 58-61*'
+venue_short: 'Interactions'
 featured: false
 ---

--- a/content/publication/qian-2026-locating/index.md
+++ b/content/publication/qian-2026-locating/index.md
@@ -11,5 +11,6 @@ publishDate: '2026-01-01'
 publication_types:
 - paper-conference
 publication: '*Proceedings of the ACM on Human-Computer Interaction 10 (2), 1-32*'
+venue_short: 'CSCW'
 featured: false
 ---

--- a/content/publication/tang-2026-beyond/index.md
+++ b/content/publication/tang-2026-beyond/index.md
@@ -14,5 +14,6 @@ publishDate: '2026-01-01'
 publication_types:
 - manuscript
 publication: '*arXiv preprint arXiv:2602.01694*'
+venue_short: 'arXiv'
 featured: false
 ---

--- a/content/publication/xiao-2025-constructing/index.md
+++ b/content/publication/xiao-2025-constructing/index.md
@@ -15,5 +15,6 @@ publishDate: '2025-01-01'
 publication_types:
 - manuscript
 publication: '*arXiv preprint arXiv:2505.20623*'
+venue_short: 'arXiv'
 featured: false
 ---

--- a/content/publication/xiao-2025-what/index.md
+++ b/content/publication/xiao-2025-what/index.md
@@ -13,5 +13,6 @@ publishDate: '2025-01-01'
 publication_types:
 - manuscript
 publication: '*arXiv preprint arXiv:2506.05687*'
+venue_short: 'arXiv'
 featured: false
 ---

--- a/data/meanwhile.yaml
+++ b/data/meanwhile.yaml
@@ -20,10 +20,6 @@
   src: /media/meanwhile/cat.jpg
   alt: "cat resting on a green quilt"
 
-- type: image
-  src: /media/meanwhile/shoes-black.jpg
-  alt: "black lace-up sneakers with white socks"
-
 - type: collage
   columns: 2
   items:

--- a/layouts/partials/blox/recent-pubs.html
+++ b/layouts/partials/blox/recent-pubs.html
@@ -27,6 +27,8 @@
     <div class="bio-pub-entry">
       <div class="bio-pub-meta">
         {{ if $typeLabel }}<span class="pub-badge {{ $typeClass }}">{{ $typeLabel }}</span>{{ end }}
+        {{ $vs := .Params.venue_short_override | default .Params.venue_short }}
+        {{ if $vs }}<span class="venue-short-tag">{{ $vs }}</span>{{ end }}
         <span class="bio-pub-year">{{ .Date.Format "2006" }}</span>
       </div>
       <h4 class="bio-pub-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h4>

--- a/layouts/project/list.html
+++ b/layouts/project/list.html
@@ -12,18 +12,17 @@
       <span class="projects-section-label">Current Work</span>
     </div>
     {{ range $i, $p := $active.ByDate.Reverse }}
-    <div class="project-row">
-      <div class="project-row-left">
-        <span class="project-row-num">{{ printf "%02d" (add $i 1) }}</span>
-        <span class="project-active-tag">Active</span>
-      </div>
-      <div class="project-row-right">
-        {{ if .Params.tags }}
-        <div class="project-tags">
+    <div class="project-accordion" id="proj-active-{{ $i }}">
+      <button class="project-accordion-trigger" onclick="toggleAccordion('proj-active-{{ $i }}')" aria-expanded="false">
+        <span class="project-accordion-num">{{ printf "%02d" (add $i 1) }}</span>
+        <span class="project-accordion-title">{{ .Title }}</span>
+        <span class="project-accordion-tags">
           {{ range .Params.tags }}<span class="project-tag">{{ . }}</span>{{ end }}
-        </div>
-        {{ end }}
-        <h3 class="project-title">{{ .Title }}</h3>
+        </span>
+        <span class="project-active-tag">Active</span>
+        <span class="project-accordion-arrow">↓</span>
+      </button>
+      <div class="project-accordion-body">
         {{ with .Params.summary }}<p class="project-summary">{{ . }}</p>{{ end }}
       </div>
     </div>
@@ -39,17 +38,16 @@
       <span class="projects-section-label">Research Themes</span>
     </div>
     {{ range $i, $p := $themes.ByDate.Reverse }}
-    <div class="project-row">
-      <div class="project-row-left">
-        <span class="project-row-num">{{ printf "%02d" (add $i 1) }}</span>
-      </div>
-      <div class="project-row-right">
-        {{ if .Params.tags }}
-        <div class="project-tags">
+    <div class="project-accordion" id="proj-theme-{{ $i }}">
+      <button class="project-accordion-trigger" onclick="toggleAccordion('proj-theme-{{ $i }}')" aria-expanded="false">
+        <span class="project-accordion-num">{{ printf "%02d" (add $i 1) }}</span>
+        <span class="project-accordion-title">{{ .Title }}</span>
+        <span class="project-accordion-tags">
           {{ range .Params.tags }}<span class="project-tag">{{ . }}</span>{{ end }}
-        </div>
-        {{ end }}
-        <h3 class="project-title">{{ .Title }}</h3>
+        </span>
+        <span class="project-accordion-arrow">↓</span>
+      </button>
+      <div class="project-accordion-body">
         {{ with .Params.summary }}<p class="project-summary">{{ . }}</p>{{ end }}
 
         {{ with .Params.related_pubs }}
@@ -65,7 +63,9 @@
                 {{ $t := index . 0 }}
                 {{ if eq $t "article-journal" }}Journal{{ else if eq $t "paper-conference" }}Conference{{ else if eq $t "chapter" }}Workshop{{ else if eq $t "manuscript" }}Preprint{{ end }}
               {{ end }}
-              {{ if .Date }}· {{ .Date.Format "2006" }}{{ end }}
+              {{ $vs := .Params.venue_short_override | default .Params.venue_short }}
+              {{ if $vs }} · {{ $vs }}{{ end }}
+              {{ if .Date }} · {{ .Date.Format "2006" }}{{ end }}
             </span>
           </a>
           {{ end }}
@@ -80,4 +80,24 @@
   {{ end }}
 
 </section>
+
+<script>
+function toggleAccordion(id) {
+  var el = document.getElementById(id);
+  if (!el) return;
+  var isOpen = el.classList.contains('is-open');
+
+  // Close all others
+  document.querySelectorAll('.project-accordion.is-open').forEach(function(a) {
+    a.classList.remove('is-open');
+    a.querySelector('.project-accordion-trigger').setAttribute('aria-expanded', 'false');
+  });
+
+  // Open this one (unless it was already open)
+  if (!isOpen) {
+    el.classList.add('is-open');
+    el.querySelector('.project-accordion-trigger').setAttribute('aria-expanded', 'true');
+  }
+}
+</script>
 {{ end }}

--- a/layouts/publication/list.html
+++ b/layouts/publication/list.html
@@ -48,6 +48,8 @@
             {{ if $typeLabel }}
             <span class="pub-badge {{ $typeClass }}">{{ $typeLabel }}</span>
             {{ end }}
+            {{ $vs := .Params.venue_short_override | default .Params.venue_short }}
+            {{ if $vs }}<span class="venue-short-tag">{{ $vs }}</span>{{ end }}
             {{ with .Params.publication }}
             <span class="pub-venue">{{ . | markdownify }}</span>
             {{ end }}

--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -24,6 +24,8 @@
       {{ if $typeLabel }}
       <span class="pub-badge {{ $typeClass }}">{{ $typeLabel }}</span>
       {{ end }}
+      {{ $vs := .Params.venue_short_override | default .Params.venue_short }}
+      {{ if $vs }}<span class="venue-short-tag">{{ $vs }}</span>{{ end }}
       <span class="pub-single-date">{{ .Date.Format "2006" }}</span>
     </div>
 

--- a/scripts/fetch_scholar.py
+++ b/scripts/fetch_scholar.py
@@ -187,6 +187,62 @@ def venue_to_entry_type(venue: str) -> str:
     return "article"
 
 
+# Ordered list of (keywords, short_tag). First match wins.
+VENUE_SHORT_MAP: list[tuple[list[str], str]] = [
+    # HCI / CHI family
+    (["chi conference", "human factors in computing systems", "proceedings of chi", "acm chi"], "CHI"),
+    (["cscw", "computer-supported cooperative work", "proceedings of the acm on human-computer interaction", "pacmhci"], "CSCW"),
+    (["uist", "user interface software and technology"], "UIST"),
+    (["assets", "assistive technology"], "ASSETS"),
+    (["iui", "intelligent user interfaces"], "IUI"),
+    (["dis ", "designing interactive systems"], "DIS"),
+    (["group conference", " group '", "acm group"], "GROUP"),
+    (["ecscw"], "ECSCW"),
+    (["interact "], "INTERACT"),
+    (["nordichi"], "NordiCHI"),
+    # AI Ethics / Safety
+    (["facct", "fairness, accountability", "fat*", "fatml"], "FAccT"),
+    (["aies", "ai, ethics, and society"], "AIES"),
+    (["eaamo", "equity and access in algorithms"], "EAAMO"),
+    # NLP / ML
+    (["emnlp"], "EMNLP"),
+    (["naacl"], "NAACL"),
+    (["neurips", "neural information processing systems"], "NeurIPS"),
+    (["iclr", "international conference on learning representations"], "ICLR"),
+    (["icml", "international conference on machine learning"], "ICML"),
+    # Social / Web Computing
+    (["icwsm"], "ICWSM"),
+    (["websci", "web science"], "WebSci"),
+    (["world wide web", " www "], "WWW"),
+    (["wsdm"], "WSDM"),
+    (["kdd"], "KDD"),
+    (["recsys"], "RecSys"),
+    # Security / Privacy
+    (["soups", "symposium on usable privacy"], "SOUPS"),
+    (["ieee symposium on security", "ieee s&p"], "IEEE S&P"),
+    (["acm ccs", " ccs "], "CCS"),
+    (["usenix security"], "USENIX Security"),
+    # Journals
+    (["tochi", "transactions on computer-human interaction"], "TOCHI"),
+    (["tacl", "transactions of the association for computational linguistics"], "TACL"),
+    (["communications of the acm", "cacm"], "CACM"),
+    (["big data & society"], "Big Data & Society"),
+    # Preprint
+    (["arxiv"], "arXiv"),
+]
+
+
+def detect_venue_short(venue: str) -> str:
+    """Return a short venue tag (e.g. 'CHI', 'CSCW') from a full venue string."""
+    if not venue:
+        return ""
+    v = venue.lower()
+    for keywords, short in VENUE_SHORT_MAP:
+        if any(kw in v for kw in keywords):
+            return short
+    return ""
+
+
 # ── BibTeX ────────────────────────────────────────────────────────────────────
 
 def paper_to_bibtex(paper: dict) -> str:
@@ -234,13 +290,14 @@ def paper_to_hugo_markdown(paper: dict) -> tuple[str, str]:
     entry_type = venue_to_entry_type(venue)
     pub_type = "paper-conference" if entry_type == "inproceedings" else "article-journal"
 
+    venue_short = detect_venue_short(venue) or detect_venue_short(venue_raw)
+
     folder = make_folder_name(authors_raw, year, title)
 
-    # YAML-safe title (escape single quotes)
     safe_title = title.replace("'", "''")
     safe_venue = venue.replace("'", "''") if venue else ""
-
     authors_yaml = "\n".join(f"- {a}" for a in author_list)
+    venue_short_line = f"venue_short: '{venue_short}'\n" if venue_short else ""
 
     content = f"""---
 title: '{safe_title}'
@@ -251,7 +308,7 @@ publishDate: '{date}'
 publication_types:
 - {pub_type}
 publication: '{"*" + safe_venue + "*" if safe_venue else ""}'
-featured: false
+{venue_short_line}featured: false
 ---
 """
     return folder, content
@@ -283,26 +340,30 @@ def write_hugo_folders(papers: list[dict]) -> None:
 
         folder_path.mkdir(exist_ok=True)
 
-        # Respect manual date override: if existing index.md has
-        # `date_manual: true`, preserve its date field.
+        # Preserve manual overrides from existing index.md
         existing_md = folder_path / "index.md"
         if existing_md.exists():
             import re as _re
             existing_text = existing_md.read_text(encoding="utf-8")
+
+            # date_manual: true → keep the existing date field
             if "date_manual: true" in existing_text:
                 m = _re.search(r"date: '([^']+)'", existing_text)
                 if m:
-                    content = _re.sub(
-                        r"(date: ')([^']+)(')",
-                        lambda x: x.group(1) + m.group(1) + x.group(3),
-                        content,
-                        count=1,
-                    )
-                    content = content.replace(
-                        "featured: false",
-                        "date_manual: true\nfeatured: false",
-                    )
+                    content = _re.sub(r"date: '[^']+'", f"date: '{m.group(1)}'", content, count=1)
+                    content = content.replace("featured: false", "date_manual: true\nfeatured: false")
                     print(f"  Kept manual date for: {folder_name}")
+
+            # venue_short_override: 'X' → use X for venue_short, re-add override field
+            m2 = _re.search(r"venue_short_override: '([^']*)'", existing_text)
+            if m2:
+                override = m2.group(1)
+                content = _re.sub(r"venue_short: '[^']*'\n", "", content)
+                content = content.replace(
+                    "featured: false",
+                    f"venue_short: '{override}'\nvenue_short_override: '{override}'\nfeatured: false",
+                )
+                print(f"  Kept venue_short_override for: {folder_name}")
 
         (folder_path / "index.md").write_text(content, encoding="utf-8")
 


### PR DESCRIPTION
## Summary

### Venue short tags (CHI, CSCW, FAccT, etc.)
- Scraper now detects the short venue name from the full venue string and writes `venue_short:` to each publication's front matter
- Full map covers: CHI, CSCW (including PACMHCI), UIST, ASSETS, IUI, DIS, FAccT, AIES, EAAMO, EMNLP, NAACL, NeurIPS, ICWSM, WebSci, SOUPS, TOCHI, arXiv, and more
- All existing publication files patched with detected `venue_short`
- **Manual override for preprints**: add `venue_short_override: 'Under Review at CHI'` to any pub's front matter — the scraper will preserve it on resync and use it instead of auto-detected value
- Venue tag shown as a small teal chip on: publications list page, publication single page, bio recent-pubs section

### Projects page — horizontal accordion
- Entries start **collapsed**: show index number + italic title + tag chips in a single line
- **Click to expand**: summary and linked publications slide open smoothly
- Only one entry open at a time (clicking another closes the current one)
- Arrow rotates on open/close
- Publication links inside show: type · venue_short · year

### Meanwhile
- Removed sneaker photo from `data/meanwhile.yaml`

## Test plan
- [ ] Publications list: verify CHI/CSCW/arXiv chips appear next to type badge
- [ ] Publications with no detected venue show no chip (graceful fallback)
- [ ] Add `venue_short_override: 'CHI 2026'` to a preprint — verify it shows correctly and survives a scraper run
- [ ] Projects page: entries collapsed on load, click opens one, click another closes previous
- [ ] Meanwhile: sneaker photo no longer shown

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_