### PR TITLE
Navbar: match cream background in light mode

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,3 +1,13 @@
+/* ── Navbar matches cream background in light mode ───────────────────────── */
+/* Hugo Blox sets .dark on <html> for dark mode — exclude it so dark mode
+   keeps its own navbar color; only override for light (default) mode.      */
+html:not(.dark) header,
+html:not(.dark) #navbar-main,
+html:not(.dark) .navbar {
+  background-color: var(--bg) !important;
+  border-bottom-color: rgba(128,128,128,0.1) !important;
+}
+
 /* ── Color palette ───────────────────────────────────────────────────────── */
 :root {
   --bg:            #F2EDE4;          /* cream — page background              */


### PR DESCRIPTION
## Summary

Hugo Blox adds the `.dark` class to `<html>` when dark mode is active. By targeting `html:not(.dark) header` we set the navbar background to `var(--bg)` (cream `#F2EDE4`) only in light mode, leaving the dark mode navbar completely untouched.

Targets `header`, `#navbar-main`, and `.navbar` to cover the Hugo Blox element hierarchy.

## Test plan
- [ ] Light mode: navbar background is cream, blends with the page
- [ ] Dark mode: navbar background is unchanged (dark)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_