### PR TITLE
Fix meanwhile image cropping on laptop/wide screens

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -895,13 +895,26 @@ body {
   width: 100vw;
 }
 
-/* Full-bleed image */
-.mag-full-img {
+/* Blurred background fill — covers the slide, blurs to fill letterbox areas */
+.mag-bg-img {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
+  filter: blur(28px) brightness(0.5);
+  transform: scale(1.08);
+  display: block;
+}
+
+/* Sharp foreground image — contain so nothing gets cropped */
+.mag-full-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  z-index: 1;
   display: block;
 }
 
@@ -913,6 +926,7 @@ body {
   right: 0;
   padding: 2rem 2.5rem;
   background: linear-gradient(transparent, rgba(0,0,0,0.6));
+  z-index: 2;
 }
 
 .mag-caption {
@@ -955,6 +969,7 @@ body {
   right: 0;
   padding: 2.5rem;
   background: linear-gradient(transparent, rgba(60,26,91,0.85));
+  z-index: 2;
 }
 
 .mag-travel-label {

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -159,7 +159,7 @@ body {
 
 .bio-info-row {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
   gap: 3rem;
   width: 100%;
 }
@@ -232,7 +232,7 @@ body {
   padding: 0.2rem 0;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 768px) {
   .bio-info-row {
     grid-template-columns: 1fr;
     gap: 2rem;

--- a/content/publication/qian-2026-human/index.md
+++ b/content/publication/qian-2026-human/index.md
@@ -13,5 +13,7 @@ publishDate: '2026-01-01'
 publication_types:
 - chapter
 publication: ''
+venue_short: 'CHI'
+venue_short_override: 'CHI'
 featured: false
 ---

--- a/content/publication/qian-2026-worker/index.md
+++ b/content/publication/qian-2026-worker/index.md
@@ -12,5 +12,7 @@ publishDate: '2026-01-01'
 publication_types:
 - paper-conference
 publication: ''
+venue_short: 'CHI'
+venue_short_override: 'CHI'
 featured: false
 ---

--- a/content/publication/tang-2026-beyond/index.md
+++ b/content/publication/tang-2026-beyond/index.md
@@ -14,6 +14,7 @@ publishDate: '2026-01-01'
 publication_types:
 - manuscript
 publication: '*arXiv preprint arXiv:2602.01694*'
-venue_short: 'arXiv'
+venue_short: 'FAccT'
+venue_short_override: 'FAccT'
 featured: false
 ---

--- a/layouts/meanwhile/list.html
+++ b/layouts/meanwhile/list.html
@@ -16,6 +16,7 @@
       {{/* ── full-bleed image ── */}}
       {{ if eq .type "image" }}
       {{ if .src }}
+      <img class="mag-bg-img" src="{{ .src }}" alt="" aria-hidden="true">
       <img class="mag-full-img" src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">
       <div class="mag-slide-overlay">
         {{ with .caption }}<p class="mag-caption">{{ . }}</p>{{ end }}
@@ -25,6 +26,7 @@
       {{/* ── travel: full-bleed image + text panel ── */}}
       {{ else if eq .type "travel" }}
       {{ if .src }}
+      <img class="mag-bg-img" src="{{ .src }}" alt="" aria-hidden="true">
       <img class="mag-full-img" src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">
       {{ end }}
       <div class="mag-travel-content">


### PR DESCRIPTION
## Summary

- Portrait photos in the Meanwhile magazine were getting heavily cropped on landscape (laptop/desktop) screens because `object-fit: cover` filled the full-viewport slide by cropping the sides/top
- Now uses two `<img>` elements per image/travel slide:
  - **Background**: blurred + dimmed version (`object-fit: cover`, `filter: blur(28px) brightness(0.5)`) fills the letterbox areas with a soft tinted glow
  - **Foreground**: sharp image (`object-fit: contain`, `z-index: 1`) — nothing ever gets cropped regardless of aspect ratio
- Caption overlay and travel text panel bumped to `z-index: 2` to stay on top of the foreground image
- Mobile (portrait viewport) looks identical to before since contain and cover produce the same result when the photo and screen share the same orientation

## Test plan
- [ ] Check a portrait photo (e.g. the cat photo) in Meanwhile on a laptop — should show full image with blurred background, no cropping
- [ ] Check the same on mobile — should still look full-bleed and correct
- [ ] Verify collage slides are unaffected (they don't use `.mag-full-img`)
- [ ] Verify text slides are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_