### PR TITLE
fix: preserve mixed-case venue tags (FAccT, arXiv, etc.)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -589,9 +589,8 @@ body {
 
 .venue-short-tag {
   font-size: 0.65rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-weight: 700;
+  letter-spacing: 0.03em;
   padding: 0.15rem 0.5rem;
   border-radius: 2px;
   background: var(--teal-subtle);


### PR DESCRIPTION
## Summary

- Removes `text-transform: uppercase` from `.venue-short-tag` — this was forcing all venue labels to ALL CAPS, breaking intentional mixed-case names like **FAccT** (→ was showing as FACCT) and **arXiv** (→ was showing as ARXIV)
- Tightens `letter-spacing` from `0.08em` to `0.03em` since the tag is now mixed-case rather than all-caps

## Test plan
- [ ] Check a FAccT paper (e.g. `cazacu-2026-actualizing`) — tag should show **FAccT** not FACCT
- [ ] Check `qian-2023-cleaning` — tag should show **arXiv** not ARXIV
- [ ] Check CHI, CSCW, UIST papers — still look correct (all-caps stays all-caps naturally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_