### PR TITLE
redesign: projects page — flat list with teal sidebar bar (Option C)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -620,7 +620,7 @@ body {
   flex-shrink: 0;
 }
 
-/* ── Projects page — accordion layout ───────────────────────────────────── */
+/* ── Projects page — sidebar-bar layout ─────────────────────────────────── */
 
 .projects-page {
   max-width: 860px;
@@ -639,156 +639,121 @@ body {
 .projects-subtitle {
   font-size: 0.95rem;
   opacity: 0.5;
-  margin: 0 0 3rem;
+  margin: 0 0 2.5rem;
 }
 
-.projects-section {
-  margin-bottom: 4rem;
-}
-
-/* Section label with teal rule */
-.projects-section-rule {
+.projects-list {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 1.5rem;
+  flex-direction: column;
+  margin-top: 2rem;
 }
 
-.projects-section-rule::before {
-  content: '';
-  display: block;
-  height: 1px;
-  width: 1.5rem;
-  background: var(--teal);
-  flex-shrink: 0;
+/* Each project row — teal left bar appears on hover/open */
+.project-item {
+  border-left: 2px solid transparent;
+  transition: border-color 0.2s;
 }
 
-.projects-section-rule::after {
-  content: '';
-  flex: 1;
-  height: 1px;
-  background: rgba(128,128,128,0.15);
+.project-item:hover,
+.project-item.is-open {
+  border-left-color: var(--teal);
 }
 
-.projects-section-label {
-  font-size: 0.7rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--teal);
-  flex-shrink: 0;
-}
-
-/* ── Accordion ───────────────────────────────────────────────────────────── */
-
-.project-accordion {
-  border-bottom: 1px solid rgba(128,128,128,0.1);
-}
-
-.project-accordion:first-of-type {
-  border-top: 1px solid rgba(128,128,128,0.1);
-}
-
-.project-accordion-trigger {
+.project-trigger {
   width: 100%;
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 1.1rem 0;
+  gap: 1.25rem;
+  padding: 1.1rem 0.5rem 1.1rem 1.5rem;
   background: none;
   border: none;
+  border-top: 1px solid rgba(128,128,128,0.1);
   cursor: pointer;
   text-align: left;
-  transition: opacity 0.15s;
 }
 
-.project-accordion-trigger:hover {
-  opacity: 0.75;
+.project-item:last-child .project-trigger {
+  border-bottom: 1px solid rgba(128,128,128,0.1);
 }
 
-.project-accordion-num {
-  font-family: 'Lora', Georgia, serif;
-  font-style: italic;
-  font-size: 1.1rem;
-  font-weight: 400;
-  color: var(--teal);
-  opacity: 0.45;
+.project-item.is-open .project-trigger {
+  border-bottom: none;
+}
+
+.project-num {
+  font-size: 0.72rem;
+  color: var(--deep-purple);
+  opacity: 0.3;
   flex-shrink: 0;
-  width: 2rem;
-  text-align: right;
+  width: 1.6rem;
+  font-variant-numeric: tabular-nums;
 }
 
-.project-accordion-title {
-  font-family: 'Lora', Georgia, serif;
-  font-size: 1.05rem;
-  font-weight: 600;
-  font-style: italic;
+.project-info {
   flex: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.project-title-text {
+  font-size: 1.02rem;
+  font-weight: 600;
   line-height: 1.3;
 }
 
-.project-accordion-tags {
+.project-tags {
   display: flex;
   flex-wrap: wrap;
   gap: 0.3rem;
-  flex-shrink: 0;
 }
 
 .project-tag {
-  font-size: 0.65rem;
-  letter-spacing: 0.03em;
+  font-size: 0.64rem;
+  letter-spacing: 0.02em;
   padding: 0.1rem 0.4rem;
   border: 1px solid rgba(128,128,128,0.2);
   border-radius: 2px;
-  opacity: 0.55;
+  opacity: 0.5;
 }
 
-.project-active-tag {
-  font-size: 0.6rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--coral);
-  border: 1px solid var(--coral-soft);
-  padding: 0.1rem 0.4rem;
-  border-radius: 2px;
-  flex-shrink: 0;
-}
-
-.project-accordion-arrow {
+.project-arrow {
   font-size: 0.85rem;
-  opacity: 0.35;
+  opacity: 0.3;
   flex-shrink: 0;
   transition: transform 0.25s ease, opacity 0.2s;
 }
 
-.project-accordion.is-open .project-accordion-arrow {
+.project-item.is-open .project-arrow {
   transform: rotate(180deg);
-  opacity: 0.7;
+  opacity: 0.65;
 }
 
-/* Accordion body — hidden by default, slides open */
-.project-accordion-body {
+/* Expanded body */
+.project-body {
   max-height: 0;
   overflow: hidden;
-  transition: max-height 0.35s ease, padding 0.25s ease;
-  padding: 0 0 0 3rem;
+  transition: max-height 0.35s ease;
+  padding-left: calc(1.5rem + 1.6rem + 1.25rem);
 }
 
-.project-accordion.is-open .project-accordion-body {
-  max-height: 600px;
-  padding: 0 0 1.5rem 3rem;
+.project-item.is-open .project-body {
+  max-height: 700px;
+  padding-bottom: 1.75rem;
+  border-bottom: 1px solid rgba(128,128,128,0.1);
 }
 
 .project-summary {
   font-size: 0.9rem;
   line-height: 1.7;
   opacity: 0.62;
-  margin: 0 0 1.25rem;
+  margin: 0.75rem 0 1.25rem;
   max-width: 52ch;
 }
 
-/* Publication list inside accordion */
+/* Publication list inside expanded body */
 .project-pubs {
   display: flex;
   flex-direction: column;

--- a/layouts/project/list.html
+++ b/layouts/project/list.html
@@ -4,50 +4,20 @@
   <h1 class="projects-title">{{ .Title }}</h1>
   {{ with .Description }}<p class="projects-subtitle">{{ . }}</p>{{ end }}
 
-  {{/* ── Current Work ── */}}
-  {{ $active := where .Pages "Params.status" "active" }}
-  {{ if $active }}
-  <div class="projects-section">
-    <div class="projects-section-rule">
-      <span class="projects-section-label">Current Work</span>
-    </div>
-    {{ range $i, $p := $active.ByDate.Reverse }}
-    <div class="project-accordion" id="proj-active-{{ $i }}">
-      <button class="project-accordion-trigger" onclick="toggleAccordion('proj-active-{{ $i }}')" aria-expanded="false">
-        <span class="project-accordion-num">{{ printf "%02d" (add $i 1) }}</span>
-        <span class="project-accordion-title">{{ .Title }}</span>
-        <span class="project-accordion-tags">
-          {{ range .Params.tags }}<span class="project-tag">{{ . }}</span>{{ end }}
+  <div class="projects-list">
+    {{ range $i, $p := .Pages.ByDate.Reverse }}
+    <div class="project-item" id="proj-{{ $i }}">
+      <button class="project-trigger" onclick="toggleProject('proj-{{ $i }}')" aria-expanded="false">
+        <span class="project-num">{{ printf "%02d" (add $i 1) }}</span>
+        <span class="project-info">
+          <span class="project-title-text">{{ .Title }}</span>
+          <span class="project-tags">
+            {{ range .Params.tags }}<span class="project-tag">{{ . }}</span>{{ end }}
+          </span>
         </span>
-        <span class="project-active-tag">Active</span>
-        <span class="project-accordion-arrow">↓</span>
+        <span class="project-arrow">↓</span>
       </button>
-      <div class="project-accordion-body">
-        {{ with .Params.summary }}<p class="project-summary">{{ . }}</p>{{ end }}
-      </div>
-    </div>
-    {{ end }}
-  </div>
-  {{ end }}
-
-  {{/* ── Research Themes ── */}}
-  {{ $themes := where .Pages "Params.status" "theme" }}
-  {{ if $themes }}
-  <div class="projects-section">
-    <div class="projects-section-rule">
-      <span class="projects-section-label">Research Themes</span>
-    </div>
-    {{ range $i, $p := $themes.ByDate.Reverse }}
-    <div class="project-accordion" id="proj-theme-{{ $i }}">
-      <button class="project-accordion-trigger" onclick="toggleAccordion('proj-theme-{{ $i }}')" aria-expanded="false">
-        <span class="project-accordion-num">{{ printf "%02d" (add $i 1) }}</span>
-        <span class="project-accordion-title">{{ .Title }}</span>
-        <span class="project-accordion-tags">
-          {{ range .Params.tags }}<span class="project-tag">{{ . }}</span>{{ end }}
-        </span>
-        <span class="project-accordion-arrow">↓</span>
-      </button>
-      <div class="project-accordion-body">
+      <div class="project-body">
         {{ with .Params.summary }}<p class="project-summary">{{ . }}</p>{{ end }}
 
         {{ with .Params.related_pubs }}
@@ -77,26 +47,23 @@
     </div>
     {{ end }}
   </div>
-  {{ end }}
 
 </section>
 
 <script>
-function toggleAccordion(id) {
+function toggleProject(id) {
   var el = document.getElementById(id);
   if (!el) return;
   var isOpen = el.classList.contains('is-open');
 
-  // Close all others
-  document.querySelectorAll('.project-accordion.is-open').forEach(function(a) {
+  document.querySelectorAll('.project-item.is-open').forEach(function(a) {
     a.classList.remove('is-open');
-    a.querySelector('.project-accordion-trigger').setAttribute('aria-expanded', 'false');
+    a.querySelector('.project-trigger').setAttribute('aria-expanded', 'false');
   });
 
-  // Open this one (unless it was already open)
   if (!isOpen) {
     el.classList.add('is-open');
-    el.querySelector('.project-accordion-trigger').setAttribute('aria-expanded', 'true');
+    el.querySelector('.project-trigger').setAttribute('aria-expanded', 'true');
   }
 }
 </script>


### PR DESCRIPTION
- Remove Current Work / Research Themes section groupings — all projects in one flat list sorted by date
- Left bar: 2px teal border on hover/open instead of horizontal divider
- Numbers, title, and tags inline in trigger row
- Body expands with padding aligned to the title column
- Removes project-accordion-* CSS; new project-item/trigger/body classes


Claude-Session: https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw