### PR TITLE
fix: align recent publications with news column on bio page

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -46,16 +46,19 @@ body {
   color: var(--text);
 }
 
-/* ── Break Hugo Blox width constraints for bio/info sections ─────────────── */
+/* ── Break Hugo Blox width constraints for bio/info/pubs sections ────────── */
 #bio,
-#info {
+#info,
+#pubs {
   width: 100%;
 }
 
 #bio > *,
 #bio > * > *,
 #info > *,
-#info > * > * {
+#info > * > *,
+#pubs > *,
+#pubs > * > * {
   max-width: none !important;
   width: 100% !important;
   box-sizing: border-box;


### PR DESCRIPTION
## Summary

The Recent Publications block (`#pubs`) was being constrained by Hugo Blox's default `max-width` container, while the info row (`#info`) above it had its max-width stripped. This caused their left edges to be at different horizontal positions.

Fix: add `#pubs` to the same width-override CSS rules that `#bio` and `#info` already use — so all three sections go full-width and share the same `padding-left: 2.5rem` origin, aligning the "Recent Publications" heading with the "Recent News" column above it.

## Test plan
- [ ] Bio homepage: "Recent Publications" heading left-aligns with the "Recent News" column in the row above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_