### PR TITLE
feat: meanwhile page-flip animation with ← → navigation

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -798,7 +798,7 @@ body {
   .project-pub-meta { white-space: normal; }
 }
 
-/* ── Meanwhile — magazine format ─────────────────────────────────────────── */
+/* ── Meanwhile — magazine page-flip format ───────────────────────────────── */
 
 .mag-outer {
   display: flex;
@@ -807,7 +807,7 @@ body {
   overflow: hidden;
 }
 
-/* Top bar: title + view toggle */
+/* Top bar: title + page counter */
 .mag-topbar {
   display: flex;
   align-items: center;
@@ -826,63 +826,97 @@ body {
   letter-spacing: -0.01em;
 }
 
-.mag-view-toggle {
-  display: flex;
-  gap: 0.35rem;
+.mag-counter {
+  font-size: 0.72rem;
+  opacity: 0.4;
+  letter-spacing: 0.05em;
 }
 
-.mag-toggle-btn {
+/* Book: stacks all slides on top of each other */
+.mag-book {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: var(--deep-purple);
+  perspective: 1800px;
+}
+
+/* Individual slide — hidden by default, JS reveals active */
+.mag-slide {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  background: var(--deep-purple);
+  visibility: hidden;
+  z-index: 0;
+  transform-origin: left center;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+
+/* ── Page flip animations ── */
+
+/* Forward: current page folds away to the left */
+@keyframes flipOutFwd {
+  from { transform: perspective(1800px) rotateY(0deg);    opacity: 1; }
+  to   { transform: perspective(1800px) rotateY(-90deg);  opacity: 0.2; }
+}
+/* Forward: next page unfolds from the right */
+@keyframes flipInFwd {
+  from { transform: perspective(1800px) rotateY(90deg);   opacity: 0.2; }
+  to   { transform: perspective(1800px) rotateY(0deg);    opacity: 1; }
+}
+
+/* Backward: current page folds away to the right */
+@keyframes flipOutBack {
+  from { transform: perspective(1800px) rotateY(0deg);    opacity: 1; transform-origin: right center; }
+  to   { transform: perspective(1800px) rotateY(90deg);   opacity: 0.2; transform-origin: right center; }
+}
+/* Backward: previous page unfolds from the left */
+@keyframes flipInBack {
+  from { transform: perspective(1800px) rotateY(-90deg);  opacity: 0.2; }
+  to   { transform: perspective(1800px) rotateY(0deg);    opacity: 1; }
+}
+
+.mag-slide.flip-out-fwd  { animation: flipOutFwd  0.45s ease-in  forwards; visibility: visible; z-index: 3; }
+.mag-slide.flip-in-fwd   { animation: flipInFwd   0.45s ease-out forwards; visibility: visible; z-index: 1; animation-delay: 0.2s; }
+.mag-slide.flip-out-back { animation: flipOutBack 0.45s ease-in  forwards; visibility: visible; z-index: 3; }
+.mag-slide.flip-in-back  { animation: flipInBack  0.45s ease-out forwards; visibility: visible; z-index: 1; animation-delay: 0.2s; }
+
+/* Prev / Next navigation bar */
+.mag-nav {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.6rem 2rem;
+  border-top: 1px solid rgba(128,128,128,0.1);
+  background: var(--bg);
+  flex-shrink: 0;
+}
+
+.mag-nav-btn {
   font-family: 'Lora', Georgia, serif;
-  font-size: 0.72rem;
-  padding: 0.25rem 0.65rem;
-  border: 1px solid rgba(128,128,128,0.25);
-  border-radius: 3px;
+  font-size: 1rem;
+  padding: 0.3rem 1.2rem;
   background: none;
+  border: 1px solid rgba(128,128,128,0.2);
+  border-radius: 3px;
   cursor: pointer;
-  opacity: 0.5;
+  opacity: 0.55;
   transition: opacity 0.15s, border-color 0.15s;
 }
 
-.mag-toggle-btn.is-active {
+.mag-nav-btn:not(:disabled):hover {
   opacity: 1;
   border-color: var(--teal);
   color: var(--teal);
 }
 
-/* Slide container — vertical scroll-snap */
-.mag-slides {
-  flex: 1;
-  overflow-y: scroll;
-  scroll-snap-type: y mandatory;
-  -webkit-overflow-scrolling: touch;
+.mag-nav-btn:disabled {
+  opacity: 0.2;
+  cursor: default;
 }
 
-/* Slide container — horizontal */
-.mag-slides.mag-horizontal {
-  overflow-y: hidden;
-  overflow-x: scroll;
-  scroll-snap-type: x mandatory;
-  display: flex;
-  flex-wrap: nowrap;
-}
-
-/* Individual slide */
-.mag-slide {
-  position: relative;
-  height: 100%;
-  scroll-snap-align: start;
-  flex-shrink: 0;
-  overflow: hidden;
-  background: var(--deep-purple);
-}
-
-.mag-slides.mag-horizontal .mag-slide {
-  width: 100vw;
-}
-
-/* Full-bleed image — cover with top-biased position so portrait photos
-   show the subject (usually near top) rather than cropping to the middle.
-   Override per-image via position: field in meanwhile.yaml → object-position inline style. */
+/* Full-bleed image */
 .mag-full-img {
   position: absolute;
   inset: 0;
@@ -901,6 +935,7 @@ body {
   right: 0;
   padding: 2rem 2.5rem;
   background: linear-gradient(transparent, rgba(0,0,0,0.6));
+  z-index: 2;
 }
 
 .mag-caption {
@@ -943,6 +978,7 @@ body {
   right: 0;
   padding: 2.5rem;
   background: linear-gradient(transparent, rgba(60,26,91,0.85));
+  z-index: 2;
 }
 
 .mag-travel-label {
@@ -1032,42 +1068,6 @@ body {
   font-weight: 500;
 }
 
-/* Floating next-slide arrow */
-.mag-arrow-btn {
-  position: absolute;
-  bottom: 1.75rem;
-  right: 2rem;
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  background: rgba(255,255,255,0.15);
-  border: 1px solid rgba(255,255,255,0.3);
-  color: #fff;
-  font-size: 1.1rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.15s;
-  backdrop-filter: blur(4px);
-  z-index: 10;
-}
-
-.mag-arrow-btn:hover {
-  background: rgba(255,255,255,0.28);
-}
-
-/* Light slides get a dark arrow */
-.slide-type-link .mag-arrow-btn {
-  background: rgba(0,0,0,0.08);
-  border-color: rgba(0,0,0,0.15);
-  color: var(--text);
-}
-
-.slide-type-link .mag-arrow-btn:hover {
-  background: rgba(0,0,0,0.15);
-}
-
 /* ── Collage slide ───────────────────────────────────────────────────────── */
 
 .mag-collage-fill {
@@ -1085,13 +1085,8 @@ body {
   min-height: 0;
 }
 
-.mag-collage-item.span-2 {
-  grid-column: span 2;
-}
-
-.mag-collage-item.span-3 {
-  grid-column: span 3;
-}
+.mag-collage-item.span-2 { grid-column: span 2; }
+.mag-collage-item.span-3 { grid-column: span 3; }
 
 .mag-collage-item img {
   width: 100%;

--- a/layouts/meanwhile/list.html
+++ b/layouts/meanwhile/list.html
@@ -1,17 +1,15 @@
 {{ define "main" }}
+{{ $total := len site.Data.meanwhile }}
 <div class="mag-outer">
 
   <div class="mag-topbar">
     <h1 class="mag-page-title">{{ .Title }}</h1>
-    <div class="mag-view-toggle">
-      <button class="mag-toggle-btn is-active" id="btn-vertical" onclick="setMagView('vertical')">↕ Scroll</button>
-      <button class="mag-toggle-btn" id="btn-horizontal" onclick="setMagView('horizontal')">→ Swipe</button>
-    </div>
+    <span class="mag-counter" id="mag-counter">1 / {{ $total }}</span>
   </div>
 
-  <div class="mag-slides mag-vertical" id="mag-slides">
+  <div class="mag-book" id="mag-book">
     {{ range $i, $item := site.Data.meanwhile }}
-    <div class="mag-slide slide-type-{{ .type | default "text" }}" id="mag-slide-{{ $i }}">
+    <div class="mag-slide slide-type-{{ .type | default "text" }}" id="mag-slide-{{ $i }}" data-index="{{ $i }}">
 
       {{/* ── full-bleed image ── */}}
       {{ if eq .type "image" }}
@@ -74,45 +72,81 @@
 
       {{ end }}
 
-      {{/* floating advance arrow */}}
-      {{ $total := len site.Data.meanwhile }}
-      {{ $next := add $i 1 }}
-      {{ if lt $next $total }}
-      <button class="mag-arrow-btn" onclick="magGoTo({{ $next }})" aria-label="Next">
-        <span class="mag-arrow-icon">↓</span>
-      </button>
-      {{ end }}
-
     </div>
     {{ end }}
+  </div>
+
+  {{/* Prev / Next navigation */}}
+  <div class="mag-nav">
+    <button class="mag-nav-btn" id="mag-prev" onclick="magNav(-1)" aria-label="Previous page" disabled>←</button>
+    <button class="mag-nav-btn" id="mag-next" onclick="magNav(1)" aria-label="Next page">→</button>
   </div>
 
 </div>
 
 <script>
 (function () {
-  window.magGoTo = function (index) {
-    var slide = document.getElementById('mag-slide-' + index);
-    if (!slide) return;
-    var container = document.getElementById('mag-slides');
-    var isH = container.classList.contains('mag-horizontal');
-    slide.scrollIntoView({
-      behavior: 'smooth',
-      block: isH ? 'nearest' : 'start',
-      inline: isH ? 'start' : 'nearest'
-    });
+  var total   = {{ $total }};
+  var current = 0;
+  var busy    = false;
+
+  function updateUI() {
+    document.getElementById('mag-counter').textContent = (current + 1) + ' / ' + total;
+    document.getElementById('mag-prev').disabled = current === 0;
+    document.getElementById('mag-next').disabled = current === total - 1;
+  }
+
+  window.magNav = function (dir) {
+    if (busy) return;
+    var next = current + dir;
+    if (next < 0 || next >= total) return;
+    busy = true;
+
+    var outEl  = document.getElementById('mag-slide-' + current);
+    var inEl   = document.getElementById('mag-slide-' + next);
+    var isForward = dir > 0;
+
+    /* Outgoing slide: fold away */
+    outEl.classList.add(isForward ? 'flip-out-fwd' : 'flip-out-back');
+
+    /* Incoming slide: start from edge */
+    inEl.style.visibility = 'visible';
+    inEl.style.zIndex = '1';
+    inEl.classList.add(isForward ? 'flip-in-fwd' : 'flip-in-back');
+
+    /* After outgoing animation completes, hide it */
+    var flipDuration = 450;
+    setTimeout(function () {
+      outEl.style.visibility = 'hidden';
+      outEl.style.zIndex = '0';
+      outEl.classList.remove('flip-out-fwd', 'flip-out-back');
+      inEl.classList.remove('flip-in-fwd', 'flip-in-back');
+      inEl.style.zIndex = '2';
+      current = next;
+      updateUI();
+      busy = false;
+    }, flipDuration);
   };
 
-  window.setMagView = function (mode) {
-    var container = document.getElementById('mag-slides');
-    container.className = 'mag-slides mag-' + mode;
-    document.getElementById('btn-vertical').classList.toggle('is-active', mode === 'vertical');
-    document.getElementById('btn-horizontal').classList.toggle('is-active', mode === 'horizontal');
-    document.querySelectorAll('.mag-arrow-icon').forEach(function (el) {
-      el.textContent = mode === 'vertical' ? '↓' : '→';
-    });
-    magGoTo(0);
-  };
+  /* Keyboard navigation */
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') magNav(1);
+    if (e.key === 'ArrowLeft'  || e.key === 'ArrowUp')   magNav(-1);
+  });
+
+  /* Touch swipe */
+  var touchStartX = 0;
+  var book = document.getElementById('mag-book');
+  book.addEventListener('touchstart', function (e) { touchStartX = e.touches[0].clientX; }, { passive: true });
+  book.addEventListener('touchend', function (e) {
+    var dx = e.changedTouches[0].clientX - touchStartX;
+    if (Math.abs(dx) > 50) magNav(dx < 0 ? 1 : -1);
+  }, { passive: true });
+
+  /* Init: make first slide visible */
+  var first = document.getElementById('mag-slide-0');
+  if (first) { first.style.visibility = 'visible'; first.style.zIndex = '2'; }
+  updateUI();
 })();
 </script>
 {{ end }}


### PR DESCRIPTION
## Summary

Replaces the scroll-snap / toggle layout with a proper page-flip magazine experience:

- **One slide at a time**, stacked with `position: absolute`
- **3D flip animation**: current slide rotates away from the left edge (`rotateY 0° → -90°`), then the next slide unfolds from the right (`rotateY 90° → 0°`). Going backward reverses the direction. Total transition: ~0.65s
- **Navigation**: ← → bottom bar buttons (disabled at first/last slide) + keyboard arrow keys + swipe left/right on mobile
- **Page counter** `1 / N` in the topbar replaces the old scroll/swipe toggle
- **Images**: `object-position: top center` so portrait photos show the subject rather than cropping to the middle
- All existing slide types (image, text, travel, link, collage) work unchanged

## Test plan
- [ ] Meanwhile loads showing slide 1 of N in the counter
- [ ] Clicking → advances with the page-flip animation
- [ ] Clicking ← goes back (disabled on first slide)
- [ ] Arrow keys work for navigation
- [ ] Swipe left/right on mobile navigates correctly
- [ ] Cat photo shows the cat (top of image visible, not cropped to center)
- [ ] Collage slide renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_