### PR TITLE
style: remove divider lines between recent publications on bio page

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -562,12 +562,10 @@ body {
 }
 
 .bio-pub-entry {
-  padding-bottom: 1.1rem;
-  border-bottom: 1px solid rgba(128,128,128,0.1);
+  padding-bottom: 0;
 }
 
 .bio-pub-entry:last-child {
-  border-bottom: none;
   padding-bottom: 0;
 }
 


### PR DESCRIPTION
Removes `border-bottom` and padding from `.bio-pub-entry` so the recent publications list on the bio page has no separator lines between entries — cleaner, less cluttered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_