### PR TITLE
feat: Talks & Presentations section on bio page

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -46,16 +46,22 @@ body {
   color: var(--text);
 }
 
-/* ── Break Hugo Blox width constraints for bio/info sections ─────────────── */
+/* ── Break Hugo Blox width constraints for bio/info/pubs/talks sections ──── */
 #bio,
-#info {
+#info,
+#pubs,
+#talks {
   width: 100%;
 }
 
 #bio > *,
 #bio > * > *,
 #info > *,
-#info > * > * {
+#info > * > *,
+#pubs > *,
+#pubs > * > *,
+#talks > *,
+#talks > * > * {
   max-width: none !important;
   width: 100% !important;
   box-sizing: border-box;
@@ -604,6 +610,50 @@ body {
   font-style: italic;
   opacity: 0.5;
   margin: 0;
+}
+
+/* ── Bio page: talks & presentations ────────────────────────────────────── */
+
+.bio-talks {
+  padding: 0 1.5rem 1rem 2.5rem;
+}
+
+.bio-talks-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.bio-talks-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.12rem;
+}
+
+.bio-talk-meta {
+  font-size: 0.72rem;
+  color: var(--deep-purple);
+  opacity: 0.42;
+}
+
+.bio-talk-title {
+  font-size: 0.93rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.bio-talk-venue {
+  font-size: 0.82rem;
+  font-style: italic;
+  opacity: 0.5;
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .bio-talks { padding-left: 1rem; }
 }
 
 /* ── Venue short tag ─────────────────────────────────────────────────────── */

--- a/content/_index.md
+++ b/content/_index.md
@@ -88,5 +88,24 @@ sections:
     id: pubs
     design:
       spacing:
-        padding: ["0", "0", "3rem", "0"]
+        padding: ["0", "0", "2rem", "0"]
+
+  - block: markdown
+    id: talks
+    content:
+      title: ""
+      text: |-
+        <div class="bio-talks">
+          <h3 class="bio-section-heading">Talks &amp; Presentations</h3>
+          <ul class="bio-talks-list">
+            <li>
+              <span class="bio-talk-meta">Apr 2025 · CHI Workshop</span>
+              <span class="bio-talk-title">Human Expertise for Scalable AI Evaluation and Red-Teaming</span>
+              <span class="bio-talk-venue">Workshop on Human Expertise for Scalable AI Evaluation and Red-Teaming, CHI 2025</span>
+            </li>
+          </ul>
+        </div>
+    design:
+      spacing:
+        padding: ["0", "0", "4rem", "0"]
 ---


### PR DESCRIPTION
## Summary

Adds a **Talks & Presentations** section at the bottom of the bio/homepage, below Recent Publications. Each entry shows: `date · venue type` / talk title / full venue name.

One real entry is included (CHI 2025 workshop). Add more by copying the `<li>` block in `content/_index.md` → the `#talks` block.

## Test plan
- [ ] Bio page: "Talks & Presentations" heading appears below Recent Publications, left-aligned with the news column
- [ ] CHI 2025 workshop entry renders with date, title, and venue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_