### PR TITLE
Redesign Meanwhile as embedded book widget with click-and-drag page t…

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -798,27 +798,22 @@ body {
   .project-pub-meta { white-space: normal; }
 }
 
-/* ── Meanwhile — magazine format ─────────────────────────────────────────── */
+/* ── Meanwhile — book widget ──────────────────────────────────────────────── */
 
-.mag-outer {
-  display: flex;
-  flex-direction: column;
-  height: calc(100vh - 68px);
-  overflow: hidden;
+.mag-wrapper {
+  max-width: 820px;
+  margin: 2rem auto 3rem;
+  padding: 0 1.5rem;
 }
 
-/* Top bar: title + view toggle */
-.mag-topbar {
+.mag-header {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: space-between;
-  padding: 0.75rem 2rem;
-  border-bottom: 1px solid rgba(128,128,128,0.12);
-  flex-shrink: 0;
-  background: var(--bg);
+  margin-bottom: 0.85rem;
 }
 
-.mag-page-title {
+.mag-book-title {
   font-size: 1.1rem;
   font-style: italic;
   font-weight: 600;
@@ -826,159 +821,154 @@ body {
   letter-spacing: -0.01em;
 }
 
-.mag-view-toggle {
-  display: flex;
-  gap: 0.35rem;
+.mag-counter {
+  font-size: 0.78rem;
+  opacity: 0.45;
+  font-variant-numeric: tabular-nums;
 }
 
-.mag-toggle-btn {
-  font-family: 'Lora', Georgia, serif;
-  font-size: 0.72rem;
-  padding: 0.25rem 0.65rem;
-  border: 1px solid rgba(128,128,128,0.25);
-  border-radius: 3px;
-  background: none;
-  cursor: pointer;
-  opacity: 0.5;
-  transition: opacity 0.15s, border-color 0.15s;
-}
-
-.mag-toggle-btn.is-active {
-  opacity: 1;
-  border-color: var(--teal);
-  color: var(--teal);
-}
-
-/* Slide container — vertical scroll-snap */
-.mag-slides {
-  flex: 1;
-  overflow-y: scroll;
-  scroll-snap-type: y mandatory;
-  -webkit-overflow-scrolling: touch;
-}
-
-/* Slide container — horizontal */
-.mag-slides.mag-horizontal {
-  overflow-y: hidden;
-  overflow-x: scroll;
-  scroll-snap-type: x mandatory;
-  display: flex;
-  flex-wrap: nowrap;
-}
-
-/* Individual slide */
-.mag-slide {
+/* The book container — fixed aspect ratio, page-flip perspective */
+.mag-book {
   position: relative;
-  height: 100%;
-  scroll-snap-align: start;
-  flex-shrink: 0;
+  width: 100%;
+  aspect-ratio: 4 / 3;
   overflow: hidden;
-  background: var(--deep-purple);
+  background: var(--bg);
+  box-shadow:
+    0 1px 3px rgba(0,0,0,0.07),
+    0 4px 16px rgba(0,0,0,0.10),
+    0 16px 48px rgba(0,0,0,0.08);
+  border-radius: 2px;
+  user-select: none;
+  /* spine shadow on left edge */
+  border-left: 5px solid rgba(0,0,0,0.07);
 }
 
-.mag-slides.mag-horizontal .mag-slide {
-  width: 100vw;
-}
-
-/* Full-bleed image — cover with top-biased position so portrait photos
-   show the subject (usually near top) rather than cropping to the middle.
-   Override per-image via position: field in meanwhile.yaml → object-position inline style. */
-.mag-full-img {
+/* Individual page — absolutely stacked, flips around left edge */
+.mag-page {
   position: absolute;
   inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: top center;
-  display: block;
+  background: var(--bg);
+  transform-origin: left center;
+  backface-visibility: hidden;
+  will-change: transform;
+  overflow: hidden;
 }
 
-/* Overlay for image captions */
-.mag-slide-overlay {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 2rem 2.5rem;
-  background: linear-gradient(transparent, rgba(0,0,0,0.6));
-}
+/* ── Page content types ── */
 
-.mag-caption {
-  font-size: 0.88rem;
-  color: rgba(255,255,255,0.85);
-  margin: 0;
-  font-style: italic;
-}
-
-/* Text slide */
-.mag-text-fill {
+/* Text page: full colored fill */
+.mag-page-text {
   position: absolute;
   inset: 0;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
-  padding: 3rem 10%;
+  padding: 2.5rem 10%;
 }
 
-.mag-text-body {
-  font-size: clamp(1.25rem, 2.5vw, 2rem);
-  line-height: 1.55;
+.mag-page-text-body {
+  font-size: clamp(1rem, 2.2vw, 1.6rem);
+  line-height: 1.6;
   color: rgba(255,255,255,0.92);
-  margin: 0 0 1rem;
-  max-width: 28ch;
+  margin: 0 0 0.85rem;
+  max-width: 32ch;
 }
 
-.mag-attribution {
-  font-size: 0.85rem;
+.mag-page-attribution {
+  font-size: 0.82rem;
   color: rgba(255,255,255,0.45);
   font-style: italic;
 }
 
-/* Travel slide */
-.mag-travel-content {
+/* Image page: centered photo with breathing room */
+.mag-page-image-wrap {
   position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 2.5rem;
-  background: linear-gradient(transparent, rgba(60,26,91,0.85));
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 2.5rem 1.5rem;
+  gap: 0.75rem;
+  background: var(--bg);
+}
+
+.mag-page-photo {
+  max-width: 100%;
+  max-height: 88%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  display: block;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.14);
+}
+
+.mag-page-caption {
+  font-size: 0.78rem;
+  opacity: 0.5;
+  text-align: center;
+  font-style: italic;
+  margin: 0;
+}
+
+/* Travel page: large photo + text overlay */
+.mag-page-travel {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--deep-purple);
+}
+
+.mag-travel-photo {
+  flex: 1;
+  width: 100%;
+  object-fit: cover;
+  object-position: top center;
+  min-height: 0;
+}
+
+.mag-travel-info {
+  padding: 1.25rem 2rem 1.5rem;
+  background: var(--deep-purple);
 }
 
 .mag-travel-label {
-  font-size: 0.65rem;
+  font-size: 0.62rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--teal);
   display: block;
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.3rem;
 }
 
 .mag-travel-location {
-  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  font-size: clamp(1.2rem, 2.5vw, 2rem);
   font-style: italic;
   font-weight: 600;
   color: #fff;
-  margin: 0 0 0.3rem;
+  margin: 0 0 0.2rem;
 }
 
 .mag-travel-date {
-  font-size: 0.82rem;
-  color: rgba(255,255,255,0.55);
+  font-size: 0.78rem;
+  color: rgba(255,255,255,0.5);
   display: block;
-  margin-bottom: 0.6rem;
+  margin-bottom: 0.4rem;
 }
 
 .mag-travel-text {
-  font-size: 0.9rem;
-  color: rgba(255,255,255,0.75);
+  font-size: 0.85rem;
+  color: rgba(255,255,255,0.7);
   margin: 0;
-  max-width: 40ch;
+  max-width: 44ch;
 }
 
-/* Link slide */
-.mag-link-fill {
+/* Link page */
+.mag-page-link {
   position: absolute;
   inset: 0;
   display: flex;
@@ -986,91 +976,54 @@ body {
   background: var(--bg);
 }
 
-.mag-link-img {
+.mag-page-link-img {
   width: 100%;
-  height: 55%;
+  height: 52%;
   object-fit: cover;
   flex-shrink: 0;
 }
 
 .mag-link-body {
   flex: 1;
-  padding: 2rem 10%;
+  padding: 1.5rem 2rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
 }
 
 .mag-source-label {
-  font-size: 0.68rem;
+  font-size: 0.65rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: var(--teal);
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4rem;
 }
 
 .mag-link-title {
-  font-size: clamp(1.2rem, 2.5vw, 1.8rem);
+  font-size: clamp(1rem, 2vw, 1.5rem);
   font-weight: 600;
   font-style: italic;
-  margin: 0 0 0.75rem;
-  max-width: 30ch;
+  margin: 0 0 0.6rem;
+  max-width: 32ch;
 }
 
 .mag-link-desc {
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   opacity: 0.6;
-  margin: 0 0 1.25rem;
+  margin: 0 0 1rem;
   max-width: 44ch;
 }
 
 .mag-link-cta {
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   color: var(--teal);
   text-decoration: none;
   font-weight: 500;
 }
 
-/* Floating next-slide arrow */
-.mag-arrow-btn {
-  position: absolute;
-  bottom: 1.75rem;
-  right: 2rem;
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  background: rgba(255,255,255,0.15);
-  border: 1px solid rgba(255,255,255,0.3);
-  color: #fff;
-  font-size: 1.1rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.15s;
-  backdrop-filter: blur(4px);
-  z-index: 10;
-}
-
-.mag-arrow-btn:hover {
-  background: rgba(255,255,255,0.28);
-}
-
-/* Light slides get a dark arrow */
-.slide-type-link .mag-arrow-btn {
-  background: rgba(0,0,0,0.08);
-  border-color: rgba(0,0,0,0.15);
-  color: var(--text);
-}
-
-.slide-type-link .mag-arrow-btn:hover {
-  background: rgba(0,0,0,0.15);
-}
-
-/* ── Collage slide ───────────────────────────────────────────────────────── */
-
-.mag-collage-fill {
+/* Collage page: grid filling full page */
+.mag-page-collage {
   position: absolute;
   inset: 0;
   display: grid;
@@ -1078,37 +1031,32 @@ body {
   gap: 3px;
 }
 
-.mag-collage-item {
+.mag-collage-cell {
   position: relative;
   overflow: hidden;
   background: var(--deep-purple);
   min-height: 0;
 }
 
-.mag-collage-item.span-2 {
-  grid-column: span 2;
-}
+.mag-collage-cell.span-2 { grid-column: span 2; }
+.mag-collage-cell.span-3 { grid-column: span 3; }
 
-.mag-collage-item.span-3 {
-  grid-column: span 3;
-}
-
-.mag-collage-item img {
+.mag-collage-cell img {
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
 }
 
-.mag-collage-item.is-text {
+.mag-collage-cell.is-text {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1.5rem 2rem;
+  padding: 1.25rem 1.5rem;
 }
 
 .mag-collage-text {
-  font-size: clamp(0.9rem, 1.5vw, 1.2rem);
+  font-size: clamp(0.82rem, 1.4vw, 1.05rem);
   color: rgba(255,255,255,0.9);
   margin: 0;
   text-align: center;
@@ -1120,9 +1068,50 @@ body {
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 0.5rem 0.75rem;
+  padding: 0.4rem 0.65rem;
   background: linear-gradient(transparent, rgba(0,0,0,0.55));
-  font-size: 0.78rem;
+  font-size: 0.72rem;
   color: rgba(255,255,255,0.82);
   font-style: italic;
+}
+
+/* Footer nav buttons */
+.mag-footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 0.9rem;
+}
+
+.mag-nav-btn {
+  background: none;
+  border: 1px solid var(--deep-purple-border);
+  color: var(--deep-purple);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, opacity 0.15s;
+  line-height: 1;
+}
+
+.mag-nav-btn:hover:not(:disabled) {
+  background: var(--teal-subtle);
+}
+
+.mag-nav-btn:disabled {
+  opacity: 0.25;
+  cursor: default;
+}
+
+@media (max-width: 600px) {
+  .mag-wrapper { padding: 0 0.75rem; }
+  .mag-page-image-wrap { padding: 1.25rem 1.25rem 1rem; }
+  .mag-travel-info { padding: 0.85rem 1.25rem 1.1rem; }
+  .mag-link-body { padding: 1rem 1.25rem; }
 }

--- a/layouts/meanwhile/list.html
+++ b/layouts/meanwhile/list.html
@@ -1,52 +1,45 @@
 {{ define "main" }}
-<div class="mag-outer">
+<div class="mag-wrapper">
 
-  <div class="mag-topbar">
-    <h1 class="mag-page-title">{{ .Title }}</h1>
-    <div class="mag-view-toggle">
-      <button class="mag-toggle-btn is-active" id="btn-vertical" onclick="setMagView('vertical')">↕ Scroll</button>
-      <button class="mag-toggle-btn" id="btn-horizontal" onclick="setMagView('horizontal')">→ Swipe</button>
-    </div>
+  <div class="mag-header">
+    <h1 class="mag-book-title">{{ .Title }}</h1>
+    <span class="mag-counter" id="mag-counter">1 / {{ len site.Data.meanwhile }}</span>
   </div>
 
-  <div class="mag-slides mag-vertical" id="mag-slides">
+  <div class="mag-book" id="mag-book">
     {{ range $i, $item := site.Data.meanwhile }}
-    <div class="mag-slide slide-type-{{ .type | default "text" }}" id="mag-slide-{{ $i }}">
+    <div class="mag-page{{ if eq $i 0 }} is-current{{ end }}" id="mag-page-{{ $i }}" data-index="{{ $i }}">
 
-      {{/* ── full-bleed image ── */}}
-      {{ if eq .type "image" }}
-      {{ if .src }}
-      <img class="mag-full-img" src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy"
-           {{ with .position }}style="object-position:{{ . }}"{{ end }}>
-      <div class="mag-slide-overlay">
-        {{ with .caption }}<p class="mag-caption">{{ . }}</p>{{ end }}
+      {{/* ── text ── */}}
+      {{ if eq .type "text" }}
+      <div class="mag-page-text" {{ with .color }}style="background:{{ . }}"{{ end }}>
+        <p class="mag-page-text-body">{{ .text }}</p>
+        {{ with .attribution }}<span class="mag-page-attribution">— {{ . }}</span>{{ end }}
       </div>
-      {{ end }}
 
-      {{/* ── travel: full-bleed image + text panel ── */}}
+      {{/* ── image ── */}}
+      {{ else if eq .type "image" }}
+      <div class="mag-page-image-wrap">
+        {{ if .src }}<img class="mag-page-photo" src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">{{ end }}
+        {{ with .caption }}<p class="mag-page-caption">{{ . }}</p>{{ end }}
+      </div>
+
+      {{/* ── travel ── */}}
       {{ else if eq .type "travel" }}
-      {{ if .src }}
-      <img class="mag-full-img" src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy"
-           {{ with .position }}style="object-position:{{ . }}"{{ end }}>
-      {{ end }}
-      <div class="mag-travel-content">
-        <span class="mag-travel-label">Travel</span>
-        {{ with .location }}<h2 class="mag-travel-location">{{ . }}</h2>{{ end }}
-        {{ with .date }}<span class="mag-travel-date">{{ . }}</span>{{ end }}
-        {{ with .text }}<p class="mag-travel-text">{{ . }}</p>{{ end }}
+      <div class="mag-page-travel">
+        {{ if .src }}<img class="mag-page-photo mag-travel-photo" src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">{{ end }}
+        <div class="mag-travel-info">
+          <span class="mag-travel-label">Travel</span>
+          {{ with .location }}<h2 class="mag-travel-location">{{ . }}</h2>{{ end }}
+          {{ with .date }}<span class="mag-travel-date">{{ . }}</span>{{ end }}
+          {{ with .text }}<p class="mag-travel-text">{{ . }}</p>{{ end }}
+        </div>
       </div>
 
-      {{/* ── text block ── */}}
-      {{ else if eq .type "text" }}
-      <div class="mag-text-fill" {{ with .color }}style="background:{{ . }}"{{ end }}>
-        <p class="mag-text-body">{{ .text }}</p>
-        {{ with .attribution }}<span class="mag-attribution">— {{ . }}</span>{{ end }}
-      </div>
-
-      {{/* ── link / article ── */}}
+      {{/* ── link ── */}}
       {{ else if eq .type "link" }}
-      <div class="mag-link-fill">
-        {{ if .image }}<img class="mag-link-img" src="{{ .image }}" alt="">{{ end }}
+      <div class="mag-page-link">
+        {{ if .image }}<img class="mag-page-link-img" src="{{ .image }}" alt="">{{ end }}
         <div class="mag-link-body">
           {{ with .source }}<span class="mag-source-label">{{ . }}</span>{{ end }}
           <h2 class="mag-link-title">{{ .title }}</h2>
@@ -55,12 +48,11 @@
         </div>
       </div>
 
-      {{/* ── collage: multiple items in one slide ── */}}
+      {{/* ── collage ── */}}
       {{ else if eq .type "collage" }}
-      <div class="mag-collage-fill"
-           {{ with .columns }}style="--collage-cols:{{ . }}"{{ end }}>
+      <div class="mag-page-collage" {{ with .columns }}style="--collage-cols:{{ . }}"{{ end }}>
         {{ range .items }}
-        <div class="mag-collage-item{{ if .span }} span-{{ .span }}{{ end }}{{ if eq .type "text" }} is-text{{ end }}"
+        <div class="mag-collage-cell{{ if .span }} span-{{ .span }}{{ end }}{{ if eq .type "text" }} is-text{{ end }}"
              {{ if and (eq .type "text") .color }}style="background:{{ .color }}"{{ end }}>
           {{ if .src }}
           <img src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">
@@ -73,46 +65,246 @@
       </div>
 
       {{ end }}
-
-      {{/* floating advance arrow */}}
-      {{ $total := len site.Data.meanwhile }}
-      {{ $next := add $i 1 }}
-      {{ if lt $next $total }}
-      <button class="mag-arrow-btn" onclick="magGoTo({{ $next }})" aria-label="Next">
-        <span class="mag-arrow-icon">↓</span>
-      </button>
-      {{ end }}
-
     </div>
     {{ end }}
+  </div>
+
+  <div class="mag-footer">
+    <button class="mag-nav-btn" id="mag-btn-prev" onclick="magNav(-1)" disabled aria-label="Previous page">←</button>
+    <button class="mag-nav-btn" id="mag-btn-next" onclick="magNav(1)" aria-label="Next page">→</button>
   </div>
 
 </div>
 
 <script>
 (function () {
-  window.magGoTo = function (index) {
-    var slide = document.getElementById('mag-slide-' + index);
-    if (!slide) return;
-    var container = document.getElementById('mag-slides');
-    var isH = container.classList.contains('mag-horizontal');
-    slide.scrollIntoView({
-      behavior: 'smooth',
-      block: isH ? 'nearest' : 'start',
-      inline: isH ? 'start' : 'nearest'
+  var book    = document.getElementById('mag-book');
+  var pages   = Array.from(document.querySelectorAll('.mag-page'));
+  var counter = document.getElementById('mag-counter');
+  var btnPrev = document.getElementById('mag-btn-prev');
+  var btnNext = document.getElementById('mag-btn-next');
+  var total   = pages.length;
+  var current = 0;
+  var isAnimating = false;
+  var isDragging  = false;
+  var dragDir     = 0;
+  var dragStartX  = 0;
+  var dragProgress = 0;
+
+  function initPages() {
+    pages.forEach(function (p, i) {
+      p.style.zIndex  = i === 0 ? '2' : '1';
+      p.style.display = i === 0 ? '' : 'none';
+      p.style.transform = '';
+      p.style.transition = '';
     });
+  }
+
+  function updateUI() {
+    counter.textContent = (current + 1) + ' / ' + total;
+    btnPrev.disabled = current === 0;
+    btnNext.disabled = current === total - 1;
+  }
+
+  initPages();
+  updateUI();
+
+  function calcProgress(clientX) {
+    var rect    = book.getBoundingClientRect();
+    var dx      = clientX - dragStartX;
+    var maxDrag = rect.width * 0.65;
+    if (dragDir === 1)  return Math.max(0, Math.min(1, -dx / maxDrag));
+    if (dragDir === -1) return Math.max(0, Math.min(1,  dx / maxDrag));
+    return 0;
+  }
+
+  function applyLive(progress) {
+    dragProgress = progress;
+    if (dragDir === 1) {
+      pages[current].style.transform = 'perspective(1400px) rotateY(' + (-90 * progress) + 'deg)';
+    } else if (dragDir === -1 && current > 0) {
+      pages[current - 1].style.transform = 'perspective(1400px) rotateY(' + (-90 * (1 - progress)) + 'deg)';
+    }
+  }
+
+  function completeTurn(dir) {
+    isAnimating = true;
+    if (dir === 1 && current < total - 1) {
+      var out = pages[current];
+      var inn = pages[current + 1];
+      out.style.transition = 'transform 0.30s ease-in';
+      out.style.transform  = 'perspective(1400px) rotateY(-90deg)';
+      setTimeout(function () {
+        out.style.transition = '';
+        out.style.transform  = '';
+        out.style.display    = 'none';
+        out.style.zIndex     = '1';
+        inn.style.zIndex     = '2';
+        current++;
+        updateUI();
+        isAnimating = false;
+      }, 300);
+
+    } else if (dir === -1 && current > 0) {
+      var inn = pages[current - 1];
+      inn.style.transition = 'transform 0.30s ease-out';
+      inn.style.transform  = 'perspective(1400px) rotateY(0deg)';
+      setTimeout(function () {
+        inn.style.transition = '';
+        inn.style.transform  = '';
+        inn.style.zIndex     = '2';
+        pages[current].style.display = 'none';
+        pages[current].style.zIndex  = '1';
+        current--;
+        updateUI();
+        isAnimating = false;
+      }, 300);
+
+    } else {
+      snapBack();
+    }
+  }
+
+  function snapBack() {
+    if (dragDir === 1) {
+      var pg = pages[current];
+      pg.style.transition = 'transform 0.22s ease-out';
+      pg.style.transform  = 'perspective(1400px) rotateY(0deg)';
+      if (current + 1 < total) pages[current + 1].style.display = 'none';
+      setTimeout(function () {
+        pg.style.transition = '';
+        pg.style.transform  = '';
+        pg.style.zIndex     = '2';
+        isAnimating = false;
+      }, 220);
+
+    } else if (dragDir === -1 && current > 0) {
+      var prev = pages[current - 1];
+      prev.style.transition = 'transform 0.22s ease-in';
+      prev.style.transform  = 'perspective(1400px) rotateY(-90deg)';
+      setTimeout(function () {
+        prev.style.transition = '';
+        prev.style.display    = 'none';
+        prev.style.zIndex     = '1';
+        pages[current].style.zIndex = '2';
+        isAnimating = false;
+      }, 220);
+    } else {
+      isAnimating = false;
+    }
+    isDragging = false;
+  }
+
+  function startDrag(clientX) {
+    if (isAnimating) return false;
+    var rect     = book.getBoundingClientRect();
+    var relX     = clientX - rect.left;
+    var rightZone = relX > rect.width * 0.33;
+
+    if (rightZone && current < total - 1) {
+      dragDir = 1;
+    } else if (!rightZone && current > 0) {
+      dragDir = -1;
+    } else {
+      return false;
+    }
+
+    isDragging   = true;
+    dragStartX   = clientX;
+    dragProgress = 0;
+
+    if (dragDir === 1) {
+      pages[current + 1].style.display = '';
+      pages[current + 1].style.zIndex  = '1';
+      pages[current + 1].style.transform = '';
+      pages[current].style.zIndex = '3';
+    } else {
+      pages[current - 1].style.display   = '';
+      pages[current - 1].style.zIndex    = '2';
+      pages[current - 1].style.transform = 'perspective(1400px) rotateY(-90deg)';
+      pages[current].style.zIndex = '1';
+    }
+    return true;
+  }
+
+  /* ── mouse ── */
+  book.addEventListener('mousedown', function (e) {
+    if (startDrag(e.clientX)) e.preventDefault();
+  });
+  document.addEventListener('mousemove', function (e) {
+    if (!isDragging) return;
+    applyLive(calcProgress(e.clientX));
+  });
+  document.addEventListener('mouseup', function (e) {
+    if (!isDragging) return;
+    isDragging = false;
+    if (dragProgress > 0.28) {
+      completeTurn(dragDir);
+    } else {
+      isAnimating = true;
+      snapBack();
+    }
+  });
+
+  /* ── touch ── */
+  book.addEventListener('touchstart', function (e) {
+    startDrag(e.touches[0].clientX);
+  }, { passive: true });
+  document.addEventListener('touchmove', function (e) {
+    if (!isDragging) return;
+    applyLive(calcProgress(e.touches[0].clientX));
+  }, { passive: true });
+  document.addEventListener('touchend', function () {
+    if (!isDragging) return;
+    isDragging = false;
+    if (dragProgress > 0.28) {
+      completeTurn(dragDir);
+    } else {
+      isAnimating = true;
+      snapBack();
+    }
+  });
+
+  /* ── cursor hint on hover ── */
+  book.addEventListener('mousemove', function (e) {
+    if (isDragging) return;
+    var rect  = book.getBoundingClientRect();
+    var relX  = e.clientX - rect.left;
+    var right = relX > rect.width * 0.33;
+    if (right && current < total - 1)       book.style.cursor = 'e-resize';
+    else if (!right && current > 0)          book.style.cursor = 'w-resize';
+    else                                     book.style.cursor = 'default';
+  });
+  book.addEventListener('mouseleave', function () {
+    book.style.cursor = 'default';
+  });
+
+  /* ── buttons & keyboard ── */
+  window.magNav = function (dir) {
+    if (isAnimating) return;
+    if (dir === 1  && current >= total - 1) return;
+    if (dir === -1 && current <= 0)         return;
+    dragDir      = dir;
+    dragProgress = 0;
+
+    if (dir === 1) {
+      pages[current + 1].style.display   = '';
+      pages[current + 1].style.zIndex    = '1';
+      pages[current + 1].style.transform = '';
+      pages[current].style.zIndex = '3';
+    } else {
+      pages[current - 1].style.display   = '';
+      pages[current - 1].style.zIndex    = '2';
+      pages[current - 1].style.transform = 'perspective(1400px) rotateY(-90deg)';
+      pages[current].style.zIndex = '1';
+    }
+    completeTurn(dir);
   };
 
-  window.setMagView = function (mode) {
-    var container = document.getElementById('mag-slides');
-    container.className = 'mag-slides mag-' + mode;
-    document.getElementById('btn-vertical').classList.toggle('is-active', mode === 'vertical');
-    document.getElementById('btn-horizontal').classList.toggle('is-active', mode === 'horizontal');
-    document.querySelectorAll('.mag-arrow-icon').forEach(function (el) {
-      el.textContent = mode === 'vertical' ? '↓' : '→';
-    });
-    magGoTo(0);
-  };
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') magNav(1);
+    if (e.key === 'ArrowLeft'  || e.key === 'ArrowUp')   magNav(-1);
+  });
 })();
 </script>
 {{ end }}

--- a/layouts/meanwhile/list.html
+++ b/layouts/meanwhile/list.html
@@ -2,7 +2,6 @@
 <div class="mag-wrapper">
 
   <div class="mag-header">
-    <h1 class="mag-book-title">{{ .Title }}</h1>
     <span class="mag-counter" id="mag-counter">1 / {{ len site.Data.meanwhile }}</span>
   </div>
 


### PR DESCRIPTION
…urns

Replaces full-viewport scroll-snap layout with a centered 820px book widget (4:3 aspect ratio). Images now display with padding and object-fit:contain, eliminating portrait photo cropping entirely.

Users drag the right/left half of the book to physically turn pages — the current page folds away via real-time perspective(1400px) rotateY tracking the cursor, with snap-complete at >28% drag or snap-back otherwise. Button and keyboard nav use the same fold animation. A spine shadow on the left edge and box-shadow give it a physical book feel.


Claude-Session: https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw