### PR TITLE
Switch font from Lora to Raleway sitewide

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -34,11 +34,11 @@ html:not(.dark) .navbar {
   --coral-soft:          rgba(232,120,109,0.3);
 }
 
-/* ── Typography: Lora only ───────────────────────────────────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600&display=swap');
+/* ── Typography: Raleway ─────────────────────────────────────────────────── */
+@import url('https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600&display=swap');
 
 body, * {
-  font-family: 'Lora', Georgia, serif;
+  font-family: 'Raleway', sans-serif;
 }
 
 body {
@@ -280,7 +280,7 @@ body {
 }
 
 .pub-year-label {
-  font-family: 'Lora', Georgia, serif;
+  font-family: 'Raleway', sans-serif;
   font-size: 1.5rem;
   font-style: italic;
   font-weight: 400;
@@ -832,7 +832,7 @@ body {
 }
 
 .mag-toggle-btn {
-  font-family: 'Lora', Georgia, serif;
+  font-family: 'Raleway', sans-serif;
   font-size: 0.72rem;
   padding: 0.25rem 0.65rem;
   border: 1px solid rgba(128,128,128,0.25);


### PR DESCRIPTION
Replaces Google Fonts import and all font-family declarations. Raleway is a geometric sans-serif; fallback changed from Georgia/serif to sans-serif accordingly.


Claude-Session: https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw