### PR TITLE
News: horizontal scroll cards with optional image support

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -183,17 +183,74 @@ body {
   margin: 0 0 0.85rem;
 }
 
-/* News list */
-.bio-news-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+/* News horizontal scroll */
+.news-scroll {
+  display: flex;
+  flex-direction: row;
+  gap: 0.6rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 0.5rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--teal-soft) transparent;
+  /* fade-out right edge to hint at more content */
+  -webkit-mask-image: linear-gradient(to right, black 80%, transparent 100%);
+  mask-image: linear-gradient(to right, black 80%, transparent 100%);
 }
 
-.bio-news-list li {
-  font-size: 0.84rem;
-  line-height: 1.55;
-  padding: 0.25rem 0;
+.news-scroll::-webkit-scrollbar {
+  height: 3px;
+}
+
+.news-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.news-scroll::-webkit-scrollbar-thumb {
+  background: var(--teal-soft);
+  border-radius: 2px;
+}
+
+.news-card {
+  flex-shrink: 0;
+  width: 155px;
+  scroll-snap-align: start;
+  border: 1px solid var(--deep-purple-border);
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.news-card-img {
+  width: 100%;
+  height: 90px;
+  object-fit: cover;
+  display: block;
+  flex-shrink: 0;
+}
+
+.news-card-body {
+  padding: 0.6rem 0.7rem 0.75rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.news-card-date {
+  font-size: 0.62rem;
+  font-weight: 600;
+  color: var(--deep-purple);
+  opacity: 0.45;
+  display: block;
+}
+
+.news-card-text {
+  font-size: 0.78rem;
+  line-height: 1.5;
+  margin: 0;
 }
 
 /* Education list */

--- a/content/_index.md
+++ b/content/_index.md
@@ -48,12 +48,32 @@ sections:
         <div class="bio-info-row">
           <div class="bio-col bio-col-news">
             <h3 class="bio-section-heading">Recent News</h3>
-            <ul class="bio-news-list">
-              <li><strong>May 2025.</strong> Paper accepted at CSCW 2025: "AURA: Supporting Responsible AI Content Work"</li>
-              <li><strong>Apr 2025.</strong> Presented at CHI 2025 workshop on AI safety and red teaming</li>
-              <li><strong>Sep 2024.</strong> Started Ph.D. at Carnegie Mellon University HCII</li>
-              <li><strong>May 2024.</strong> Graduated with B.S. Computer Science from University of Minnesota</li>
-            </ul>
+            <div class="news-scroll">
+              <div class="news-card">
+                <div class="news-card-body">
+                  <span class="news-card-date">May 2025</span>
+                  <p class="news-card-text">Paper accepted at CSCW 2025: "AURA: Supporting Responsible AI Content Work"</p>
+                </div>
+              </div>
+              <div class="news-card">
+                <div class="news-card-body">
+                  <span class="news-card-date">Apr 2025</span>
+                  <p class="news-card-text">Presented at CHI 2025 workshop on AI safety and red teaming</p>
+                </div>
+              </div>
+              <div class="news-card">
+                <div class="news-card-body">
+                  <span class="news-card-date">Sep 2024</span>
+                  <p class="news-card-text">Started Ph.D. at Carnegie Mellon University HCII</p>
+                </div>
+              </div>
+              <div class="news-card">
+                <div class="news-card-body">
+                  <span class="news-card-date">May 2024</span>
+                  <p class="news-card-text">Graduated with B.S. Computer Science from University of Minnesota</p>
+                </div>
+              </div>
+            </div>
           </div>
           <div class="bio-col bio-col-education">
             <h3 class="bio-section-heading">Education</h3>
@@ -86,25 +106,6 @@ sections:
 
   - block: recent-pubs
     id: pubs
-    design:
-      spacing:
-        padding: ["0", "0", "2rem", "0"]
-
-  - block: markdown
-    id: talks
-    content:
-      title: ""
-      text: |-
-        <div class="bio-talks">
-          <h3 class="bio-section-heading">Talks &amp; Presentations</h3>
-          <ul class="bio-talks-list">
-            <li>
-              <span class="bio-talk-meta">Apr 2025 · CHI Workshop</span>
-              <span class="bio-talk-title">Human Expertise for Scalable AI Evaluation and Red-Teaming</span>
-              <span class="bio-talk-venue">Workshop on Human Expertise for Scalable AI Evaluation and Red-Teaming, CHI 2025</span>
-            </li>
-          </ul>
-        </div>
     design:
       spacing:
         padding: ["0", "0", "4rem", "0"]


### PR DESCRIPTION
## Summary
- Replaces the static news list with horizontally scrollable snap cards (155px each)
- Cards support an optional image at the top (`<img class="news-card-img">`) — just add the tag before `.news-card-body` in `_index.md`
- Thin teal scrollbar + right-edge fade hint that more cards exist
- Column size and grid placement on the bio page are unchanged
- Also removes the Talks & Presentations block (per request to go back to the drawing board on that section)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_