### PR TITLE
Fix: meanwhile template build error (unexpected EOF)

### DIFF
--- a/layouts/meanwhile/list.html
+++ b/layouts/meanwhile/list.html
@@ -1,23 +1,19 @@
 {{ define "main" }}
-{{ $total := len site.Data.meanwhile }}
-<div class="mag-outer">
+<div class="mag-wrapper">
 
-  <div class="mag-topbar">
-    <h1 class="mag-page-title">{{ .Title }}</h1>
-    <span class="mag-counter" id="mag-counter">1 / {{ $total }}</span>
+  <div class="mag-header">
+    <span class="mag-counter" id="mag-counter">1 / {{ len site.Data.meanwhile }}</span>
   </div>
 
   <div class="mag-book" id="mag-book">
     {{ range $i, $item := site.Data.meanwhile }}
-    <div class="mag-slide slide-type-{{ .type | default "text" }}" id="mag-slide-{{ $i }}" data-index="{{ $i }}">
+    <div class="mag-page{{ if eq $i 0 }} is-current{{ end }}" id="mag-page-{{ $i }}" data-index="{{ $i }}">
 
-      {{/* ── full-bleed image ── */}}
-      {{ if eq .type "image" }}
-      {{ if .src }}
-      <img class="mag-full-img" src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy"
-           {{ with .position }}style="object-position:{{ . }}"{{ end }}>
-      <div class="mag-slide-overlay">
-        {{ with .caption }}<p class="mag-caption">{{ . }}</p>{{ end }}
+      {{/* ── text ── */}}
+      {{ if eq .type "text" }}
+      <div class="mag-page-text" {{ with .color }}style="background:{{ . }}"{{ end }}>
+        <p class="mag-page-text-body">{{ .text }}</p>
+        {{ with .attribution }}<span class="mag-page-attribution">— {{ . }}</span>{{ end }}
       </div>
 
       {{/* ── image ── */}}
@@ -68,82 +64,226 @@
       </div>
 
       {{ end }}
-
     </div>
     {{ end }}
   </div>
 
-  {{/* Prev / Next navigation */}}
-  <div class="mag-nav">
-    <button class="mag-nav-btn" id="mag-prev" onclick="magNav(-1)" aria-label="Previous page" disabled>←</button>
-    <button class="mag-nav-btn" id="mag-next" onclick="magNav(1)" aria-label="Next page">→</button>
+  <div class="mag-footer">
+    <button class="mag-nav-btn" id="mag-btn-prev" onclick="magNav(-1)" disabled aria-label="Previous page">←</button>
+    <button class="mag-nav-btn" id="mag-btn-next" onclick="magNav(1)" aria-label="Next page">→</button>
   </div>
 
 </div>
 
 <script>
 (function () {
-  var total   = {{ $total }};
+  var book    = document.getElementById('mag-book');
+  var pages   = Array.from(document.querySelectorAll('.mag-page'));
+  var counter = document.getElementById('mag-counter');
+  var btnPrev = document.getElementById('mag-btn-prev');
+  var btnNext = document.getElementById('mag-btn-next');
+  var total   = pages.length;
   var current = 0;
-  var busy    = false;
+  var isAnimating = false;
+  var isDragging  = false;
+  var dragDir     = 0;
+  var dragStartX  = 0;
+  var dragProgress = 0;
 
-  function updateUI() {
-    document.getElementById('mag-counter').textContent = (current + 1) + ' / ' + total;
-    document.getElementById('mag-prev').disabled = current === 0;
-    document.getElementById('mag-next').disabled = current === total - 1;
+  function initPages() {
+    pages.forEach(function (p, i) {
+      p.style.zIndex  = i === 0 ? '2' : '1';
+      p.style.display = i === 0 ? '' : 'none';
+      p.style.transform = '';
+      p.style.transition = '';
+    });
   }
 
+  function updateUI() {
+    counter.textContent = (current + 1) + ' / ' + total;
+    btnPrev.disabled = current === 0;
+    btnNext.disabled = current === total - 1;
+  }
+
+  initPages();
+  updateUI();
+
+  function calcProgress(clientX) {
+    var rect    = book.getBoundingClientRect();
+    var dx      = clientX - dragStartX;
+    var maxDrag = rect.width * 0.65;
+    if (dragDir === 1)  return Math.max(0, Math.min(1, -dx / maxDrag));
+    if (dragDir === -1) return Math.max(0, Math.min(1,  dx / maxDrag));
+    return 0;
+  }
+
+  function applyLive(progress) {
+    dragProgress = progress;
+    if (dragDir === 1) {
+      pages[current].style.transform = 'perspective(1400px) rotateY(' + (-90 * progress) + 'deg)';
+    } else if (dragDir === -1 && current > 0) {
+      pages[current - 1].style.transform = 'perspective(1400px) rotateY(' + (-90 * (1 - progress)) + 'deg)';
+    }
+  }
+
+  function completeTurn(dir) {
+    isAnimating = true;
+    if (dir === 1 && current < total - 1) {
+      var out = pages[current];
+      var inn = pages[current + 1];
+      out.style.transition = 'transform 0.30s ease-in';
+      out.style.transform  = 'perspective(1400px) rotateY(-90deg)';
+      setTimeout(function () {
+        out.style.transition = '';
+        out.style.transform  = '';
+        out.style.display    = 'none';
+        out.style.zIndex     = '1';
+        inn.style.zIndex     = '2';
+        current++;
+        updateUI();
+        isAnimating = false;
+      }, 300);
+    } else if (dir === -1 && current > 0) {
+      var inn = pages[current - 1];
+      inn.style.transition = 'transform 0.30s ease-out';
+      inn.style.transform  = 'perspective(1400px) rotateY(0deg)';
+      setTimeout(function () {
+        inn.style.transition = '';
+        inn.style.transform  = '';
+        inn.style.zIndex     = '2';
+        pages[current].style.display = 'none';
+        pages[current].style.zIndex  = '1';
+        current--;
+        updateUI();
+        isAnimating = false;
+      }, 300);
+    } else {
+      snapBack();
+    }
+  }
+
+  function snapBack() {
+    if (dragDir === 1) {
+      var pg = pages[current];
+      pg.style.transition = 'transform 0.22s ease-out';
+      pg.style.transform  = 'perspective(1400px) rotateY(0deg)';
+      if (current + 1 < total) pages[current + 1].style.display = 'none';
+      setTimeout(function () {
+        pg.style.transition = '';
+        pg.style.transform  = '';
+        pg.style.zIndex     = '2';
+        isAnimating = false;
+      }, 220);
+    } else if (dragDir === -1 && current > 0) {
+      var prev = pages[current - 1];
+      prev.style.transition = 'transform 0.22s ease-in';
+      prev.style.transform  = 'perspective(1400px) rotateY(-90deg)';
+      setTimeout(function () {
+        prev.style.transition = '';
+        prev.style.display    = 'none';
+        prev.style.zIndex     = '1';
+        pages[current].style.zIndex = '2';
+        isAnimating = false;
+      }, 220);
+    } else {
+      isAnimating = false;
+    }
+    isDragging = false;
+  }
+
+  function startDrag(clientX) {
+    if (isAnimating) return false;
+    var rect      = book.getBoundingClientRect();
+    var relX      = clientX - rect.left;
+    var rightZone = relX > rect.width * 0.33;
+    if (rightZone && current < total - 1)  dragDir = 1;
+    else if (!rightZone && current > 0)    dragDir = -1;
+    else                                   return false;
+
+    isDragging   = true;
+    dragStartX   = clientX;
+    dragProgress = 0;
+
+    if (dragDir === 1) {
+      pages[current + 1].style.display = '';
+      pages[current + 1].style.zIndex  = '1';
+      pages[current + 1].style.transform = '';
+      pages[current].style.zIndex = '3';
+    } else {
+      pages[current - 1].style.display   = '';
+      pages[current - 1].style.zIndex    = '2';
+      pages[current - 1].style.transform = 'perspective(1400px) rotateY(-90deg)';
+      pages[current].style.zIndex = '1';
+    }
+    return true;
+  }
+
+  /* ── mouse ── */
+  book.addEventListener('mousedown', function (e) {
+    if (startDrag(e.clientX)) e.preventDefault();
+  });
+  document.addEventListener('mousemove', function (e) {
+    if (!isDragging) return;
+    applyLive(calcProgress(e.clientX));
+  });
+  document.addEventListener('mouseup', function (e) {
+    if (!isDragging) return;
+    isDragging = false;
+    if (dragProgress > 0.28) { completeTurn(dragDir); }
+    else { isAnimating = true; snapBack(); }
+  });
+
+  /* ── touch ── */
+  book.addEventListener('touchstart', function (e) {
+    startDrag(e.touches[0].clientX);
+  }, { passive: true });
+  document.addEventListener('touchmove', function (e) {
+    if (!isDragging) return;
+    applyLive(calcProgress(e.touches[0].clientX));
+  }, { passive: true });
+  document.addEventListener('touchend', function () {
+    if (!isDragging) return;
+    isDragging = false;
+    if (dragProgress > 0.28) { completeTurn(dragDir); }
+    else { isAnimating = true; snapBack(); }
+  });
+
+  /* ── cursor hint ── */
+  book.addEventListener('mousemove', function (e) {
+    if (isDragging) return;
+    var rect  = book.getBoundingClientRect();
+    var right = (e.clientX - rect.left) > rect.width * 0.33;
+    if (right && current < total - 1)   book.style.cursor = 'e-resize';
+    else if (!right && current > 0)     book.style.cursor = 'w-resize';
+    else                                book.style.cursor = 'default';
+  });
+  book.addEventListener('mouseleave', function () { book.style.cursor = 'default'; });
+
+  /* ── buttons & keyboard ── */
   window.magNav = function (dir) {
-    if (busy) return;
-    var next = current + dir;
-    if (next < 0 || next >= total) return;
-    busy = true;
-
-    var outEl  = document.getElementById('mag-slide-' + current);
-    var inEl   = document.getElementById('mag-slide-' + next);
-    var isForward = dir > 0;
-
-    /* Outgoing slide: fold away */
-    outEl.classList.add(isForward ? 'flip-out-fwd' : 'flip-out-back');
-
-    /* Incoming slide: start from edge */
-    inEl.style.visibility = 'visible';
-    inEl.style.zIndex = '1';
-    inEl.classList.add(isForward ? 'flip-in-fwd' : 'flip-in-back');
-
-    /* After outgoing animation completes, hide it */
-    var flipDuration = 450;
-    setTimeout(function () {
-      outEl.style.visibility = 'hidden';
-      outEl.style.zIndex = '0';
-      outEl.classList.remove('flip-out-fwd', 'flip-out-back');
-      inEl.classList.remove('flip-in-fwd', 'flip-in-back');
-      inEl.style.zIndex = '2';
-      current = next;
-      updateUI();
-      busy = false;
-    }, flipDuration);
+    if (isAnimating) return;
+    if (dir === 1  && current >= total - 1) return;
+    if (dir === -1 && current <= 0)         return;
+    dragDir      = dir;
+    dragProgress = 0;
+    if (dir === 1) {
+      pages[current + 1].style.display   = '';
+      pages[current + 1].style.zIndex    = '1';
+      pages[current + 1].style.transform = '';
+      pages[current].style.zIndex = '3';
+    } else {
+      pages[current - 1].style.display   = '';
+      pages[current - 1].style.zIndex    = '2';
+      pages[current - 1].style.transform = 'perspective(1400px) rotateY(-90deg)';
+      pages[current].style.zIndex = '1';
+    }
+    completeTurn(dir);
   };
 
-  /* Keyboard navigation */
   document.addEventListener('keydown', function (e) {
     if (e.key === 'ArrowRight' || e.key === 'ArrowDown') magNav(1);
     if (e.key === 'ArrowLeft'  || e.key === 'ArrowUp')   magNav(-1);
   });
-
-  /* Touch swipe */
-  var touchStartX = 0;
-  var book = document.getElementById('mag-book');
-  book.addEventListener('touchstart', function (e) { touchStartX = e.touches[0].clientX; }, { passive: true });
-  book.addEventListener('touchend', function (e) {
-    var dx = e.changedTouches[0].clientX - touchStartX;
-    if (Math.abs(dx) > 50) magNav(dx < 0 ? 1 : -1);
-  }, { passive: true });
-
-  /* Init: make first slide visible */
-  var first = document.getElementById('mag-slide-0');
-  if (first) { first.style.visibility = 'visible'; first.style.zIndex = '2'; }
-  updateUI();
 })();
 </script>
 {{ end }}


### PR DESCRIPTION
## What broke
The PR #45 merge produced a corrupted `layouts/meanwhile/list.html` — a hybrid of the old page-flip template and the new book widget template. It contained an unclosed `{{ if .src }}` block, leaving Hugo with unresolved open blocks at end-of-file, which caused the `unexpected EOF at line 150` build error.

## Fix
Replaces the file entirely with the correct book widget template: embedded 820px widget, 4:3 aspect ratio, click-and-drag page turns with real-time `rotateY` tracking, snap-complete at >28% drag, snap-back otherwise. Keyboard and touch navigation included.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_