### PR TITLE
Fix: project template build error (GroupByParam)

### DIFF
--- a/layouts/project/list.html
+++ b/layouts/project/list.html
@@ -4,7 +4,7 @@
   <h1 class="projects-title">{{ .Title }}</h1>
   {{ with .Description }}<p class="projects-subtitle">{{ . }}</p>{{ end }}
 
-  {{ range .Pages.GroupBy "Params.theme" }}
+  {{ range .Pages.GroupByParam "theme" }}
   <div class="theme-group">
     <div class="theme-label-col">
       <span class="theme-label">{{ .Key }}</span>


### PR DESCRIPTION
## What broke
`GroupBy "Params.theme"` caused a build error: `reflect: Elem of invalid type page.Page`. Hugo's `GroupBy` only accepts top-level page variables (`.Title`, `.Date`, `.Section`, etc.) — it cannot traverse into `Params`.

## Fix
Changed to `GroupByParam "theme"`, which is Hugo's documented method for grouping pages by a frontmatter field.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_