### PR TITLE
Stack education and interests in right column of bio info row

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -167,10 +167,16 @@ body {
 
 .bio-info-row {
   display: grid;
-  grid-template-columns: 1.8fr 1fr 1fr;
+  grid-template-columns: 1.8fr 1fr;
   gap: 2rem;
   width: 100%;
   padding-left: 2.5rem;
+}
+
+.bio-col-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .bio-section-heading {

--- a/content/_index.md
+++ b/content/_index.md
@@ -75,29 +75,31 @@ sections:
               </div>
             </div>
           </div>
-          <div class="bio-col bio-col-education">
-            <h3 class="bio-section-heading">Education</h3>
-            <ul class="bio-education-list">
-              <li>
-                <span class="bio-edu-degree">Ph.D. Computer Science</span>
-                <span class="bio-edu-institution">Carnegie Mellon University</span>
-                <span class="bio-edu-years">2024 – present</span>
-              </li>
-              <li>
-                <span class="bio-edu-degree">B.S. Computer Science</span>
-                <span class="bio-edu-institution">University of Minnesota</span>
-                <span class="bio-edu-years">2020 – 2024</span>
-              </li>
-            </ul>
-          </div>
-          <div class="bio-col bio-col-interests">
-            <h3 class="bio-section-heading">Interests</h3>
-            <ul class="bio-interests-list">
-              <li>human infrastructure for AI 👩🏻</li>
-              <li>AI evaluation ✅</li>
-              <li>future of work 👩🏻‍💻</li>
-              <li>social computing 🌐</li>
-            </ul>
+          <div class="bio-col-stack">
+            <div class="bio-col bio-col-education">
+              <h3 class="bio-section-heading">Education</h3>
+              <ul class="bio-education-list">
+                <li>
+                  <span class="bio-edu-degree">Ph.D. Computer Science</span>
+                  <span class="bio-edu-institution">Carnegie Mellon University</span>
+                  <span class="bio-edu-years">2024 – present</span>
+                </li>
+                <li>
+                  <span class="bio-edu-degree">B.S. Computer Science</span>
+                  <span class="bio-edu-institution">University of Minnesota</span>
+                  <span class="bio-edu-years">2020 – 2024</span>
+                </li>
+              </ul>
+            </div>
+            <div class="bio-col bio-col-interests">
+              <h3 class="bio-section-heading">Interests</h3>
+              <ul class="bio-interests-list">
+                <li>human infrastructure for AI 👩🏻</li>
+                <li>AI evaluation ✅</li>
+                <li>future of work 👩🏻‍💻</li>
+                <li>social computing 🌐</li>
+              </ul>
+            </div>
           </div>
         </div>
     design:


### PR DESCRIPTION
## Summary
- Wraps the education and interests blocks in a shared `bio-col-stack` div so they sit directly above/below each other
- Changes `bio-info-row` from a 3-column grid (`1.8fr 1fr 1fr`) to 2-column (`1.8fr 1fr`)
- Adds `.bio-col-stack { display: flex; flex-direction: column; gap: 1.5rem }` to stack the two sections

## Test plan
- [ ] Bio info row has news on the left, education + interests stacked on the right
- [ ] No horizontal gap between education and interests — they sit close together
- [ ] Mobile (≤768px) still collapses to single column

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_