### PR TITLE
Meanwhile: open-book layout with bottom-of-page flip animation

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -889,142 +889,162 @@ body {
   .project-pub-row { flex-direction: column; gap: 0.1rem; }
 }
 
-/* ── Meanwhile — magazine page-flip format ───────────────────────────────── */
+/* ── Meanwhile — open-book page-flip ─────────────────────────────────────── */
 
 .mag-wrapper {
-  max-width: 820px;
+  max-width: 860px;
   margin: 2rem auto 3rem;
   padding: 0 1.5rem;
 }
 
-/* Top bar: title + page counter */
-.mag-topbar {
+/* Header: page counter */
+.mag-header {
   display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  margin-bottom: 0.85rem;
-}
-
-.mag-book-title {
-  font-size: 1.1rem;
-  font-style: italic;
-  font-weight: 600;
-  margin: 0;
-  letter-spacing: -0.01em;
+  align-items: center;
+  justify-content: flex-end;
+  margin-bottom: 0.6rem;
 }
 
 .mag-counter {
   font-size: 0.72rem;
   opacity: 0.4;
   letter-spacing: 0.05em;
+  font-variant-numeric: tabular-nums;
 }
 
-/* Book: stacks all slides on top of each other */
-.mag-book {
+/* Open-book shell: left decorative leaf + spine + right active leaf */
+.mag-book-shell {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  aspect-ratio: 1.9 / 1;
+  box-shadow:
+    0 1px 3px rgba(0,0,0,0.06),
+    0 6px 20px rgba(0,0,0,0.10),
+    0 20px 60px rgba(0,0,0,0.07);
+  border-radius: 2px;
+  overflow: hidden;
+  user-select: none;
+}
+
+/* Decorative left page — lined paper look */
+.mag-left-leaf {
+  width: 44%;
+  flex-shrink: 0;
+  background-color: #faf8f4;
+  background-image:
+    repeating-linear-gradient(
+      transparent, transparent 27px,
+      rgba(0,0,0,0.055) 27px, rgba(0,0,0,0.055) 28px
+    );
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-start;
+  padding: 1.25rem 1.5rem;
+}
+
+.dark .mag-left-leaf {
+  background-color: #1c1228;
+  background-image:
+    repeating-linear-gradient(
+      transparent, transparent 27px,
+      rgba(255,255,255,0.04) 27px, rgba(255,255,255,0.04) 28px
+    );
+}
+
+.mag-left-label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--deep-purple);
+  opacity: 0.28;
+}
+
+/* Spine — gradient shadow between leaves */
+.mag-spine {
+  width: 12px;
+  flex-shrink: 0;
+  background: linear-gradient(
+    to right,
+    rgba(0,0,0,0.10) 0%,
+    rgba(0,0,0,0.03) 50%,
+    rgba(0,0,0,0.08) 100%
+  );
+  z-index: 4;
+}
+
+/* Right leaf — active content with pages stacked inside */
+.mag-right-leaf,
+#mag-book {
   flex: 1;
   position: relative;
   overflow: hidden;
-  background: var(--deep-purple);
-  perspective: 1800px;
+  background: var(--bg);
 }
 
-/* Individual slide — hidden by default, JS reveals active */
-.mag-slide {
+/* Individual page — bottom lifts on forward flip */
+.mag-page {
   position: absolute;
   inset: 0;
-  overflow: hidden;
-  background: var(--deep-purple);
-  visibility: hidden;
-  z-index: 0;
-  transform-origin: left center;
+  background: var(--bg);
+  transform-origin: top center;
   backface-visibility: hidden;
   -webkit-backface-visibility: hidden;
+  will-change: transform;
+  overflow: hidden;
 }
 
-/* ── Page flip animations ── */
+/* ── Page content types ─────────────────────────────────────────────────── */
 
-/* Forward: current page folds away to the left */
-@keyframes flipOutFwd {
-  from { transform: perspective(1800px) rotateY(0deg);    opacity: 1; }
-  to   { transform: perspective(1800px) rotateY(-90deg);  opacity: 0.2; }
-}
-/* Forward: next page unfolds from the right */
-@keyframes flipInFwd {
-  from { transform: perspective(1800px) rotateY(90deg);   opacity: 0.2; }
-  to   { transform: perspective(1800px) rotateY(0deg);    opacity: 1; }
-}
-
-/* Backward: current page folds away to the right */
-@keyframes flipOutBack {
-  from { transform: perspective(1800px) rotateY(0deg);    opacity: 1; transform-origin: right center; }
-  to   { transform: perspective(1800px) rotateY(90deg);   opacity: 0.2; transform-origin: right center; }
-}
-/* Backward: previous page unfolds from the left */
-@keyframes flipInBack {
-  from { transform: perspective(1800px) rotateY(-90deg);  opacity: 0.2; }
-  to   { transform: perspective(1800px) rotateY(0deg);    opacity: 1; }
-}
-
-.mag-slide.flip-out-fwd  { animation: flipOutFwd  0.45s ease-in  forwards; visibility: visible; z-index: 3; }
-.mag-slide.flip-in-fwd   { animation: flipInFwd   0.45s ease-out forwards; visibility: visible; z-index: 1; animation-delay: 0.2s; }
-.mag-slide.flip-out-back { animation: flipOutBack 0.45s ease-in  forwards; visibility: visible; z-index: 3; }
-.mag-slide.flip-in-back  { animation: flipInBack  0.45s ease-out forwards; visibility: visible; z-index: 1; animation-delay: 0.2s; }
-
-/* Prev / Next navigation bar */
-.mag-nav {
-  display: flex;
-  justify-content: space-between;
-  padding: 0.6rem 2rem;
-  border-top: 1px solid rgba(128,128,128,0.1);
-  background: var(--bg);
-  flex-shrink: 0;
-}
-
-.mag-nav-btn {
-  font-family: 'Lora', Georgia, serif;
-  font-size: 1rem;
-  padding: 0.3rem 1.2rem;
-  background: none;
-  border: 1px solid rgba(128,128,128,0.2);
-  border-radius: 3px;
-  cursor: pointer;
-  opacity: 0.55;
-  transition: opacity 0.15s, border-color 0.15s;
-}
-
-.mag-nav-btn:not(:disabled):hover {
-  opacity: 1;
-  border-color: var(--teal);
-  color: var(--teal);
-}
-
-.mag-nav-btn:disabled {
-  opacity: 0.2;
-  cursor: default;
-}
-
-/* Full-bleed image */
-.mag-full-img {
+/* Text page */
+.mag-page-text {
   position: absolute;
   inset: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 2rem 2.5rem 1.5rem;
-  gap: 0.75rem;
+  padding: 2.5rem 3rem;
+  background: var(--bg);
+  text-align: center;
+}
+
+.mag-page-text-body {
+  font-size: clamp(1rem, 2vw, 1.35rem);
+  font-style: italic;
+  font-weight: 400;
+  line-height: 1.65;
+  margin: 0 0 0.75rem;
+  max-width: 38ch;
+}
+
+.mag-page-attribution {
+  font-size: 0.78rem;
+  opacity: 0.5;
+  display: block;
+}
+
+/* Image page */
+.mag-page-image-wrap {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1.75rem 2rem 1.25rem;
+  gap: 0.65rem;
   background: var(--bg);
 }
 
-/* Overlay for image captions */
-.mag-slide-overlay {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 2rem 2.5rem;
-  background: linear-gradient(transparent, rgba(0,0,0,0.6));
-  z-index: 2;
+.mag-page-photo {
+  max-width: 100%;
+  max-height: calc(100% - 2.5rem);
+  object-fit: contain;
+  display: block;
 }
 
 .mag-page-caption {
@@ -1052,13 +1072,13 @@ body {
   min-height: 0;
 }
 
-/* Travel slide */
-.mag-travel-content {
+/* Travel info overlay */
+.mag-travel-info {
   position: absolute;
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 2.5rem;
+  padding: 1.5rem 2rem;
   background: linear-gradient(transparent, rgba(60,26,91,0.85));
   z-index: 2;
 }
@@ -1150,9 +1170,9 @@ body {
   font-weight: 500;
 }
 
-/* ── Collage slide ───────────────────────────────────────────────────────── */
+/* ── Collage page ─────────────────────────────────────────────────────────── */
 
-.mag-collage-fill {
+.mag-page-collage {
   position: absolute;
   inset: 0;
   display: grid;
@@ -1167,10 +1187,10 @@ body {
   min-height: 0;
 }
 
-.mag-collage-item.span-2 { grid-column: span 2; }
-.mag-collage-item.span-3 { grid-column: span 3; }
+.mag-collage-cell.span-2 { grid-column: span 2; }
+.mag-collage-cell.span-3 { grid-column: span 3; }
 
-.mag-collage-item img {
+.mag-collage-cell img {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -1240,6 +1260,8 @@ body {
 
 @media (max-width: 600px) {
   .mag-wrapper { padding: 0 0.75rem; }
+  .mag-book-shell { aspect-ratio: 4 / 3; }
+  .mag-left-leaf, .mag-spine { display: none; }
   .mag-page-image-wrap { padding: 1.25rem 1.25rem 1rem; }
   .mag-travel-info { padding: 0.85rem 1.25rem 1.1rem; }
   .mag-link-body { padding: 1rem 1.25rem; }

--- a/layouts/meanwhile/list.html
+++ b/layouts/meanwhile/list.html
@@ -5,67 +5,73 @@
     <span class="mag-counter" id="mag-counter">1 / {{ len site.Data.meanwhile }}</span>
   </div>
 
-  <div class="mag-book" id="mag-book">
-    {{ range $i, $item := site.Data.meanwhile }}
-    <div class="mag-page{{ if eq $i 0 }} is-current{{ end }}" id="mag-page-{{ $i }}" data-index="{{ $i }}">
+  <div class="mag-book-shell">
+    <div class="mag-left-leaf" aria-hidden="true">
+      <span class="mag-left-label">meanwhile</span>
+    </div>
+    <div class="mag-spine" aria-hidden="true"></div>
+    <div class="mag-right-leaf" id="mag-book">
+      {{ range $i, $item := site.Data.meanwhile }}
+      <div class="mag-page{{ if eq $i 0 }} is-current{{ end }}" id="mag-page-{{ $i }}" data-index="{{ $i }}">
 
-      {{/* ── text ── */}}
-      {{ if eq .type "text" }}
-      <div class="mag-page-text" {{ with .color }}style="background:{{ . }}"{{ end }}>
-        <p class="mag-page-text-body">{{ .text }}</p>
-        {{ with .attribution }}<span class="mag-page-attribution">— {{ . }}</span>{{ end }}
-      </div>
-
-      {{/* ── image ── */}}
-      {{ else if eq .type "image" }}
-      <div class="mag-page-image-wrap">
-        {{ if .src }}<img class="mag-page-photo" src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">{{ end }}
-        {{ with .caption }}<p class="mag-page-caption">{{ . }}</p>{{ end }}
-      </div>
-
-      {{/* ── travel ── */}}
-      {{ else if eq .type "travel" }}
-      <div class="mag-page-travel">
-        {{ if .src }}<img class="mag-page-photo mag-travel-photo" src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">{{ end }}
-        <div class="mag-travel-info">
-          <span class="mag-travel-label">Travel</span>
-          {{ with .location }}<h2 class="mag-travel-location">{{ . }}</h2>{{ end }}
-          {{ with .date }}<span class="mag-travel-date">{{ . }}</span>{{ end }}
-          {{ with .text }}<p class="mag-travel-text">{{ . }}</p>{{ end }}
+        {{/* ── text ── */}}
+        {{ if eq .type "text" }}
+        <div class="mag-page-text" {{ with .color }}style="background:{{ . }}"{{ end }}>
+          <p class="mag-page-text-body">{{ .text }}</p>
+          {{ with .attribution }}<span class="mag-page-attribution">— {{ . }}</span>{{ end }}
         </div>
-      </div>
 
-      {{/* ── link ── */}}
-      {{ else if eq .type "link" }}
-      <div class="mag-page-link">
-        {{ if .image }}<img class="mag-page-link-img" src="{{ .image }}" alt="">{{ end }}
-        <div class="mag-link-body">
-          {{ with .source }}<span class="mag-source-label">{{ . }}</span>{{ end }}
-          <h2 class="mag-link-title">{{ .title }}</h2>
-          {{ with .description }}<p class="mag-link-desc">{{ . }}</p>{{ end }}
-          <a class="mag-link-cta" href="{{ .url }}" target="_blank" rel="noopener">Read ↗</a>
+        {{/* ── image ── */}}
+        {{ else if eq .type "image" }}
+        <div class="mag-page-image-wrap">
+          {{ if .src }}<img class="mag-page-photo" src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">{{ end }}
+          {{ with .caption }}<p class="mag-page-caption">{{ . }}</p>{{ end }}
         </div>
-      </div>
 
-      {{/* ── collage ── */}}
-      {{ else if eq .type "collage" }}
-      <div class="mag-page-collage" {{ with .columns }}style="--collage-cols:{{ . }}"{{ end }}>
-        {{ range .items }}
-        <div class="mag-collage-cell{{ if .span }} span-{{ .span }}{{ end }}{{ if eq .type "text" }} is-text{{ end }}"
-             {{ if and (eq .type "text") .color }}style="background:{{ .color }}"{{ end }}>
-          {{ if .src }}
-          <img src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">
-          {{ with .caption }}<div class="mag-collage-caption">{{ . }}</div>{{ end }}
-          {{ else if eq .type "text" }}
-          <p class="mag-collage-text">{{ .text }}</p>
+        {{/* ── travel ── */}}
+        {{ else if eq .type "travel" }}
+        <div class="mag-page-travel">
+          {{ if .src }}<img class="mag-page-photo mag-travel-photo" src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">{{ end }}
+          <div class="mag-travel-info">
+            <span class="mag-travel-label">Travel</span>
+            {{ with .location }}<h2 class="mag-travel-location">{{ . }}</h2>{{ end }}
+            {{ with .date }}<span class="mag-travel-date">{{ . }}</span>{{ end }}
+            {{ with .text }}<p class="mag-travel-text">{{ . }}</p>{{ end }}
+          </div>
+        </div>
+
+        {{/* ── link ── */}}
+        {{ else if eq .type "link" }}
+        <div class="mag-page-link">
+          {{ if .image }}<img class="mag-page-link-img" src="{{ .image }}" alt="">{{ end }}
+          <div class="mag-link-body">
+            {{ with .source }}<span class="mag-source-label">{{ . }}</span>{{ end }}
+            <h2 class="mag-link-title">{{ .title }}</h2>
+            {{ with .description }}<p class="mag-link-desc">{{ . }}</p>{{ end }}
+            <a class="mag-link-cta" href="{{ .url }}" target="_blank" rel="noopener">Read ↗</a>
+          </div>
+        </div>
+
+        {{/* ── collage ── */}}
+        {{ else if eq .type "collage" }}
+        <div class="mag-page-collage" {{ with .columns }}style="--collage-cols:{{ . }}"{{ end }}>
+          {{ range .items }}
+          <div class="mag-collage-cell{{ if .span }} span-{{ .span }}{{ end }}{{ if eq .type "text" }} is-text{{ end }}"
+               {{ if and (eq .type "text") .color }}style="background:{{ .color }}"{{ end }}>
+            {{ if .src }}
+            <img src="{{ .src }}" alt="{{ .alt | default "" }}" loading="lazy">
+            {{ with .caption }}<div class="mag-collage-caption">{{ . }}</div>{{ end }}
+            {{ else if eq .type "text" }}
+            <p class="mag-collage-text">{{ .text }}</p>
+            {{ end }}
+          </div>
           {{ end }}
         </div>
+
         {{ end }}
       </div>
-
       {{ end }}
     </div>
-    {{ end }}
   </div>
 
   <div class="mag-footer">
@@ -87,7 +93,7 @@
   var isAnimating = false;
   var isDragging  = false;
   var dragDir     = 0;
-  var dragStartX  = 0;
+  var dragStartY  = 0;
   var dragProgress = 0;
 
   function initPages() {
@@ -108,21 +114,21 @@
   initPages();
   updateUI();
 
-  function calcProgress(clientX) {
+  function calcProgress(clientY) {
     var rect    = book.getBoundingClientRect();
-    var dx      = clientX - dragStartX;
-    var maxDrag = rect.width * 0.65;
-    if (dragDir === 1)  return Math.max(0, Math.min(1, -dx / maxDrag));
-    if (dragDir === -1) return Math.max(0, Math.min(1,  dx / maxDrag));
+    var dy      = clientY - dragStartY;
+    var maxDrag = rect.height * 0.65;
+    if (dragDir === 1)  return Math.max(0, Math.min(1, -dy / maxDrag)); /* drag up = forward */
+    if (dragDir === -1) return Math.max(0, Math.min(1,  dy / maxDrag)); /* drag down = backward */
     return 0;
   }
 
   function applyLive(progress) {
     dragProgress = progress;
     if (dragDir === 1) {
-      pages[current].style.transform = 'perspective(1400px) rotateY(' + (-90 * progress) + 'deg)';
+      pages[current].style.transform = 'perspective(1400px) rotateX(' + (-90 * progress) + 'deg)';
     } else if (dragDir === -1 && current > 0) {
-      pages[current - 1].style.transform = 'perspective(1400px) rotateY(' + (-90 * (1 - progress)) + 'deg)';
+      pages[current - 1].style.transform = 'perspective(1400px) rotateX(' + (-90 * (1 - progress)) + 'deg)';
     }
   }
 
@@ -131,8 +137,8 @@
     if (dir === 1 && current < total - 1) {
       var out = pages[current];
       var inn = pages[current + 1];
-      out.style.transition = 'transform 0.30s ease-in';
-      out.style.transform  = 'perspective(1400px) rotateY(-90deg)';
+      out.style.transition = 'transform 0.32s ease-in';
+      out.style.transform  = 'perspective(1400px) rotateX(-90deg)';
       setTimeout(function () {
         out.style.transition = '';
         out.style.transform  = '';
@@ -142,11 +148,11 @@
         current++;
         updateUI();
         isAnimating = false;
-      }, 300);
+      }, 320);
     } else if (dir === -1 && current > 0) {
       var inn = pages[current - 1];
-      inn.style.transition = 'transform 0.30s ease-out';
-      inn.style.transform  = 'perspective(1400px) rotateY(0deg)';
+      inn.style.transition = 'transform 0.32s ease-out';
+      inn.style.transform  = 'perspective(1400px) rotateX(0deg)';
       setTimeout(function () {
         inn.style.transition = '';
         inn.style.transform  = '';
@@ -156,7 +162,7 @@
         current--;
         updateUI();
         isAnimating = false;
-      }, 300);
+      }, 320);
     } else {
       snapBack();
     }
@@ -166,7 +172,7 @@
     if (dragDir === 1) {
       var pg = pages[current];
       pg.style.transition = 'transform 0.22s ease-out';
-      pg.style.transform  = 'perspective(1400px) rotateY(0deg)';
+      pg.style.transform  = 'perspective(1400px) rotateX(0deg)';
       if (current + 1 < total) pages[current + 1].style.display = 'none';
       setTimeout(function () {
         pg.style.transition = '';
@@ -177,7 +183,7 @@
     } else if (dragDir === -1 && current > 0) {
       var prev = pages[current - 1];
       prev.style.transition = 'transform 0.22s ease-in';
-      prev.style.transform  = 'perspective(1400px) rotateY(-90deg)';
+      prev.style.transform  = 'perspective(1400px) rotateX(-90deg)';
       setTimeout(function () {
         prev.style.transition = '';
         prev.style.display    = 'none';
@@ -191,17 +197,18 @@
     isDragging = false;
   }
 
-  function startDrag(clientX) {
+  function startDrag(clientY) {
     if (isAnimating) return false;
-    var rect      = book.getBoundingClientRect();
-    var relX      = clientX - rect.left;
-    var rightZone = relX > rect.width * 0.33;
-    if (rightZone && current < total - 1)  dragDir = 1;
-    else if (!rightZone && current > 0)    dragDir = -1;
+    var rect     = book.getBoundingClientRect();
+    var relY     = clientY - rect.top;
+    var bottomHalf = relY > rect.height * 0.45;
+
+    if (bottomHalf && current < total - 1) dragDir = 1;   /* bottom zone → drag up → forward */
+    else if (!bottomHalf && current > 0)   dragDir = -1;  /* top zone → drag down → backward */
     else                                   return false;
 
     isDragging   = true;
-    dragStartX   = clientX;
+    dragStartY   = clientY;
     dragProgress = 0;
 
     if (dragDir === 1) {
@@ -212,7 +219,7 @@
     } else {
       pages[current - 1].style.display   = '';
       pages[current - 1].style.zIndex    = '2';
-      pages[current - 1].style.transform = 'perspective(1400px) rotateY(-90deg)';
+      pages[current - 1].style.transform = 'perspective(1400px) rotateX(-90deg)';
       pages[current].style.zIndex = '1';
     }
     return true;
@@ -220,13 +227,13 @@
 
   /* ── mouse ── */
   book.addEventListener('mousedown', function (e) {
-    if (startDrag(e.clientX)) e.preventDefault();
+    if (startDrag(e.clientY)) e.preventDefault();
   });
   document.addEventListener('mousemove', function (e) {
     if (!isDragging) return;
-    applyLive(calcProgress(e.clientX));
+    applyLive(calcProgress(e.clientY));
   });
-  document.addEventListener('mouseup', function (e) {
+  document.addEventListener('mouseup', function () {
     if (!isDragging) return;
     isDragging = false;
     if (dragProgress > 0.28) { completeTurn(dragDir); }
@@ -235,11 +242,11 @@
 
   /* ── touch ── */
   book.addEventListener('touchstart', function (e) {
-    startDrag(e.touches[0].clientX);
+    startDrag(e.touches[0].clientY);
   }, { passive: true });
   document.addEventListener('touchmove', function (e) {
     if (!isDragging) return;
-    applyLive(calcProgress(e.touches[0].clientX));
+    applyLive(calcProgress(e.touches[0].clientY));
   }, { passive: true });
   document.addEventListener('touchend', function () {
     if (!isDragging) return;
@@ -251,11 +258,11 @@
   /* ── cursor hint ── */
   book.addEventListener('mousemove', function (e) {
     if (isDragging) return;
-    var rect  = book.getBoundingClientRect();
-    var right = (e.clientX - rect.left) > rect.width * 0.33;
-    if (right && current < total - 1)   book.style.cursor = 'e-resize';
-    else if (!right && current > 0)     book.style.cursor = 'w-resize';
-    else                                book.style.cursor = 'default';
+    var rect   = book.getBoundingClientRect();
+    var bottom = (e.clientY - rect.top) > rect.height * 0.45;
+    if (bottom && current < total - 1)   book.style.cursor = 'n-resize';
+    else if (!bottom && current > 0)     book.style.cursor = 's-resize';
+    else                                 book.style.cursor = 'default';
   });
   book.addEventListener('mouseleave', function () { book.style.cursor = 'default'; });
 
@@ -274,7 +281,7 @@
     } else {
       pages[current - 1].style.display   = '';
       pages[current - 1].style.zIndex    = '2';
-      pages[current - 1].style.transform = 'perspective(1400px) rotateY(-90deg)';
+      pages[current - 1].style.transform = 'perspective(1400px) rotateX(-90deg)';
       pages[current].style.zIndex = '1';
     }
     completeTurn(dir);


### PR DESCRIPTION
## Summary
- Adds a decorative left leaf (lined paper texture via CSS `repeating-linear-gradient`) + spine gradient, making the widget look like an open book
- Pages now flip upward from the bottom — `transform-origin: top center` + `rotateX(-90deg)` — instead of the previous left-spine `rotateY`
- Drag gesture updated: dragging **up** on the bottom half of the page goes forward; dragging **down** on the top half goes backward
- Cursor hint changes to `n-resize` / `s-resize` accordingly
- Dark mode support for the left leaf background and line texture
- Left leaf and spine hide on mobile (≤600px) to preserve space

## Test plan
- [ ] Page looks like an open book with a lined decorative left half and content on the right
- [ ] Clicking ← / → nav buttons animates page flip (bottom lifts up for forward, drops down for backward)
- [ ] Click-and-drag on the right leaf works: drag up flips forward, drag down flips backward
- [ ] Keyboard arrow keys still navigate
- [ ] Mobile: left leaf hidden, right leaf fills full width, flips still work
- [ ] Dark mode: left leaf uses dark paper texture

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_