### PR TITLE
Remove teal left border from project items

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -769,13 +769,6 @@ body {
 
 /* Each project row */
 .project-item {
-  border-left: 2px solid transparent;
-  transition: border-color 0.2s;
-}
-
-.project-item:hover,
-.project-item.is-open {
-  border-left-color: var(--teal);
 }
 
 .project-trigger {


### PR DESCRIPTION
Removes the teal `border-left` that was popping up on hover and when a project accordion was open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYqvSEC8LZBJ44oSfEkrqw)_